### PR TITLE
Implement missing values component

### DIFF
--- a/components/annot-missing-values.vue
+++ b/components/annot-missing-values.vue
@@ -28,7 +28,7 @@
 <script>
 
     // Allows for reference to store data by creating simple, implicit getters
-    import { mapGetters } from "vuex";
+    import { mapGetters, mapState } from "vuex";
 
     export default {
 
@@ -38,8 +38,6 @@
 
             relevantColumns: { type: Array, required: true }
         },
-
-        inject: ["missingColumnValues"],
 
         data() {
 
@@ -65,31 +63,40 @@
 
             ...mapGetters([
 
-                "isMissingValue",
                 "valueDescription"
             ]),
 
+            ...mapState([
+
+                "missingColumnValues"
+            ]),
+
             tableItems() {
-                const tmp = [
-                    {
-                        column: 'sex',
-                        description: 'my description',
-                        value: 'my value'
+                let missingValueArray = []
+
+                for ( let column of this.relevantColumns ) {
+                    if ( Object.keys(this.missingColumnValues).includes(column) ) {
+                        for ( let missing_value of this.missingColumnValues[column] ) {
+                            const description = this.valueDescription(column, missing_value);
+                            missingValueArray.push(
+                                {
+                                    column: column,
+                                    description: description === null ? "" : description,
+                                    value: missing_value
+                                }
+                            )
+
+                        }
                     }
-                ]
-                return tmp
+                }
+                return missingValueArray
             }
         },
 
         methods: {
 
             removeColumn(p_tableItem) {
-
-                // 1. Remove the item from table data
-                this.tableItems = this.tableItems.filter(item =>
-                    item.column === p_tableItem.column && item.value !== p_tableItem.value );
-
-                // 2. Remove this value from the column's missing value list in the store
+                // Remove this value from the column's missing value list in the store
                 this.$emit('remove:missingValue', p_tableItem);
             }
         }

--- a/components/annot-missing-values.vue
+++ b/components/annot-missing-values.vue
@@ -1,7 +1,9 @@
 <template>
 
     <div>
-        <b-card class="annotation-card">
+        <b-card
+            no-body
+            class="annotation-card">
 
             <b-card-header>{{ uiText.title }}</b-card-header>
 

--- a/components/annot-missing-values.vue
+++ b/components/annot-missing-values.vue
@@ -74,7 +74,7 @@
             ]),
 
             tableItems() {
-                let missingValueArray = []
+                let missingValueArray = [];
 
                 for ( let column of this.relevantColumns ) {
                     if ( Object.keys(this.missingColumnValues).includes(column) ) {
@@ -86,12 +86,12 @@
                                     description: description === null ? "" : description,
                                     value: missing_value
                                 }
-                            )
+                            );
 
                         }
                     }
                 }
-                return missingValueArray
+                return missingValueArray;
             }
         },
 
@@ -102,7 +102,7 @@
                 this.$emit('remove:missingValue', p_tableItem);
             }
         }
-    }
+    };
 
 </script>
 

--- a/components/annot-missing-values.vue
+++ b/components/annot-missing-values.vue
@@ -36,8 +36,7 @@
 
         props: {
 
-            dataType: { type: String, required: true },
-            uniqueValues: { type: Object, required: true }
+            relevantColumns: { type: Array, required: true }
         },
 
         inject: ["missingColumnValues"],
@@ -54,8 +53,6 @@
                     { key: "not_missing"}
                 ],
 
-                tableItems: [],
-
                 uiText: {
 
                     notMissingButton: "Not Missing",
@@ -70,131 +67,30 @@
 
                 "isMissingValue",
                 "valueDescription"
-            ])
-        },
+            ]),
 
-        created() {
-
-            // 1. Create lists of potentially missing values for the data based on
-            // information in the data dictionary and the data type for this category
-            this.determineMissingValues();
-
-            // 2. Create an array of objects for missing value table data
-            this.createTableData();
+            tableItems() {
+                const tmp = [
+                    {
+                        column: 'sex',
+                        description: 'my description',
+                        value: 'my value'
+                    }
+                ]
+                return tmp
+            }
         },
 
         methods: {
 
-            createTableData() {
-
-                // 0. Wipe any old table data
-                this.tableItems = [];
-
-                // 1. Create a list of objects describing each value for each
-                // column listed in 'uniqueValues'
-                for ( const columnName in this.uniqueValues ) {
-                    for ( const value of this.uniqueValues[columnName] ) {
-
-                        // A. Only missing values for this data type are listed
-                        if ( this.isMissingValue(columnName, value) ) {
-
-                            this.tableItems.push({
-
-                                column: columnName,
-                                description: this.valueDescription(columnName, value),
-                                value: value
-                            });
-                        }
-                    }
-                }
-            },
-
-            determineMissingValues() {
-
-                // 0. Create an object for missing values lists for all columns of this component
-                const missingValuesLists = {};
-
-                // 1. Create a set of lists for potentially missing values of
-                // each column assigned to this tab's cateogry
-                for ( const columnName in this.uniqueValues ) {
-
-                    // A. Only determine missing values if there is no value list for this column in the store
-                    if ( Object.keys(this.missingColumnValues).includes(columnName) ) {
-                        continue;
-                    }
-
-                    // B. Each column has a list of potentially missing values
-                    missingValuesLists[columnName] = [];
-
-                    // C. Determine value invalidity based on the data type of this category
-                    for ( const value of this.uniqueValues[columnName] ) {
-
-                        switch ( this.dataType ) {
-
-                            case "categorical":
-                                if ( !this.isValidCategorical(columnName, value) ) {
-                                    missingValuesLists[columnName].push(value);
-                                }
-                                break;
-
-                            case "continuous":
-                                if ( !this.isValidContinuous(value) ) {
-                                    missingValuesLists[columnName].push(value);
-                                }
-                                break;
-
-                            case "string":
-                                if ( !this.isValidString(value) ) {
-                                    missingValuesLists[columnName].push(value);
-                                }
-                                break;
-                        }
-                    }
-                }
-
-                // 2. Save the missing values lists to the store
-                this.$emit("update:missingColumnValues", missingValuesLists);
-            },
-
-            isValidCategorical(p_column, p_value) {
-
-                let isValid = true;
-
-                // 1. Value is potentially invalid if it is missing from the data dictionary description
-                if ( null === this.valueDescription(p_column, p_value) ) {
-                    isValid = false;
-                }
-
-                return isValid;
-            },
-
-            isValidContinuous(p_value) {
-
-                let isValid = true;
-
-                // 1. Value is likely invalid if it is not numeric
-                if ( isNaN(p_value) ) {
-                    isValid = false;
-                }
-
-                return isValid;
-            },
-
-            isValidString(p_value) {
-
-                let isValid = true;
-
-                return isValid;
-            },
-
             removeColumn(p_tableItem) {
 
                 // 1. Remove the item from table data
-                this.tableItems = this.tableItems.filter(item => 
+                this.tableItems = this.tableItems.filter(item =>
                     item.column === p_tableItem.column && item.value !== p_tableItem.value );
 
                 // 2. Remove this value from the column's missing value list in the store
-                this.$emit('remove:missingValue', p_tableItem);                    
+                this.$emit('remove:missingValue', p_tableItem);
             }
         }
     }
@@ -208,5 +104,5 @@
         height: 30vh;
         overflow-y: scroll;
     }
-    
+
 </style>

--- a/components/annot-tab.vue
+++ b/components/annot-tab.vue
@@ -13,8 +13,7 @@
 
         <!-- Lists any values determined to be missing (e.g. potentially invalid) in this tab's columns -->
         <annot-missing-values
-            :data-type="details.dataType"
-            :unique-values="uniqueValues"
+            :relevant-columns="relevantColumns"
             @remove:missingValue="$emit('remove:missingValue', $event)"
             @update:missingColumnValues="$emit('update:missingColumnValues', $event)" />
 

--- a/components/annot-tab.vue
+++ b/components/annot-tab.vue
@@ -55,7 +55,7 @@
 
                 // Category of the current annotation tab
                 category: ""
-            }
+            };
         },
 
         computed: {
@@ -111,6 +111,6 @@
             // Set the given category for this tab
             this.category = this.details.category;
         }
-    }
+    };
 
 </script>

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -78,7 +78,7 @@
     import { mapGetters } from "vuex";
 
     export default {
-    
+
         name: "AnnotationPage",
 
         data() {
@@ -151,6 +151,10 @@
                 pageName: "download",
                 enable: this.isDataAnnotated
             });
+
+            // TODO: remove this, just a temporary way to add any missing values to the store
+            const missingLists = {"sex": [0, 1]}
+            this.saveMissingColumnValues(missingLists)
         },
 
         methods: {
@@ -188,7 +192,7 @@
             },
 
             saveMissingColumnValues(p_event) {
-
+                // TODO document what this thing does and expects
                 // Save the algorithm and/or user-specified missing values to the store
                 this.$store.dispatch("saveMissingColumnValues", p_event);
             },

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -153,8 +153,8 @@
             });
 
             // TODO: remove this, just a temporary way to add any missing values to the store
-            const missingLists = {"sex": [0, 1]}
-            this.saveMissingColumnValues(missingLists)
+            const missingLists = {"sex": [0, 1]};
+            this.saveMissingColumnValues(missingLists);
         },
 
         methods: {
@@ -162,7 +162,7 @@
             removeMissingValue(p_event) {
 
                 // 1. Create copy of the missing values list for this column without the value to be removed
-                const missingValuesList = {}
+                const missingValuesList = {};
                 missingValuesList[p_event.column] = [];
 
                 for ( const value of this.missingColumnValues[p_event.column] ) {

--- a/store/index.js
+++ b/store/index.js
@@ -124,7 +124,7 @@ export const state = () => ({
 	// Stores a list of (potentially) missing values for each column. This is determined in the missing-values
 	// components on the annotation page, and then amended by the user as they see fit
 	missingColumnValues: {}
-})
+});
 
 // Actions - Call mutations to change state data in order to maintain trace of
 // what component changed state data and when
@@ -325,7 +325,7 @@ export const actions = {
 
 		p_context.commit("setMissingColumnValues", p_missingColumnValues);
 	}
-}
+};
 
 // Mutations - Change state data, as called by Actions
 export const mutations = {
@@ -474,7 +474,7 @@ export const mutations = {
         p_state.missingColumnValues = Object.assign({}, p_state.missingColumnValues, p_missingColumnValues);
 
 	}
-}
+};
 
 // Getters - Give access to state data
 export const getters = {
@@ -579,7 +579,7 @@ export const getters = {
 
         return valueDescription;
     }
-}
+};
 
 // Action helpers
 function convertTsvLinesToTableData(p_tsvLines){

--- a/store/index.js
+++ b/store/index.js
@@ -8,7 +8,7 @@ export const state = () => ({
     pageData: {
 
         home: {
-            
+
             accessible: true,
             fullName: "Home",
             location: "/",
@@ -16,7 +16,7 @@ export const state = () => ({
         },
 
         categorization: {
-            
+
             accessible: false,
             fullName: "Categorization",
             location: "categorization",
@@ -24,7 +24,7 @@ export const state = () => ({
         },
 
         annotation: {
-            
+
             accessible: false,
             fullName: "Annotation",
             location: "annotation",
@@ -32,7 +32,7 @@ export const state = () => ({
         },
 
         download: {
-            
+
             accessible: false,
             fullName: "Download",
             location: "download",
@@ -90,7 +90,7 @@ export const state = () => ({
     // Hardcoded list of categories used on the categorization page
     // and possibly elsewhere in the tool
     categories: [],
-    
+
     // This is a computed direct map between current categories and CSS classes
     // See getter 'categoryClasses'
     categoryClasses: null,
@@ -125,7 +125,7 @@ export const state = () => ({
 	// components on the annotation page, and then amended by the user as they see fit
 	missingColumnValues: {}
 })
-  
+
 // Actions - Call mutations to change state data in order to maintain trace of
 // what component changed state data and when
 export const actions = {
@@ -150,7 +150,7 @@ export const actions = {
     nuxtServerInit({ commit }) {
 
         // This function is called on Nuxt server startup
-        
+
         // 0. This list is default but we can swap out and reinitialize category
         // data structures by calling store action 'initializeCategories' with
         // a new list of categories
@@ -210,7 +210,7 @@ export const actions = {
     },
 
     // Tool navigation
-    
+
     enablePageNavigation(p_context, p_navData) {
 
         p_context.commit("setPageNavigationAccess", p_navData);
@@ -244,7 +244,7 @@ export const actions = {
     },
 
     // Landing page actions
-    
+
     saveDataDictionary(p_context, p_newFileData) {
 
         // 1. Attempt to transform the string data into JSON if valid data given
@@ -262,7 +262,7 @@ export const actions = {
 
         // 1. Attempt to convert the tsv lines into a dict for each line if valid data given
         if ( "tsv"  === p_newFileData.fileType ) {
-        
+
             // 1. Save new table data, formatted for the Vue table element
             if ( null !== p_newFileData.data )
                 p_newFileData.formattedData = convertTsvLinesToTableData(p_newFileData.data);
@@ -309,7 +309,7 @@ export const actions = {
         }
 
         p_context.commit("changeColumnValues", {
-            
+
             columnName: p_columnName,
             tableToChange: p_context.state.dataTable.annotated,
             newValues: originalValues
@@ -344,7 +344,7 @@ export const mutations = {
 
         // 2. Get color keys from tool color palette
         const colorKeys = Object.keys(p_state.toolColorPalette);
-        
+
         // 3. Create the category to color map
         let assignedCategories = 0;
         for ( let index = 0; index < p_categories.length &&
@@ -374,7 +374,7 @@ export const mutations = {
             const category = p_state.categories[index];
             const colorID = p_state.categoryToColorMap[category];
             const colorClass = p_state.toolColorPalette[colorID];
-            
+
             mapArray.push([category, colorClass]);
         }
 
@@ -489,7 +489,7 @@ export const getters = {
 
         // 1. Find the description for this column in the data dictionary
         if ( null !== p_state.dataDictionary.original && Object.keys(p_state.dataDictionary.original).includes(p_columnName) ) {
-            
+
             // A. Get dictionary's description string for this column
             const dictionaryDescStr = Object.keys(p_state.dataDictionary.original[p_columnName]).find(
                 (key) => key.toLowerCase() === "description");
@@ -540,13 +540,13 @@ export const getters = {
     },
 
 	isMissingValue: (p_state) => (p_columnName, p_value) => {
+    // Checks if a column-value combination is stored in the missingColumnValues object
+    // and returns true if it is, false otherwise
 
 		if ( !Object.keys(p_state.missingColumnValues).includes(p_columnName) ) {
 			console.log(`WARNING: Could not find '${p_columnName}' in p_state.missingColumnValues`);
 		}
 
-		// Value is considered missing if it is not in the store's missing values list
-		// This is determined via determineMissingValues() and later on, the user via this component
 		return ( p_state.missingColumnValues[p_columnName].includes(p_value) );
 	},
 

--- a/store/index.js
+++ b/store/index.js
@@ -465,12 +465,14 @@ export const mutations = {
     },
 
 	setMissingColumnValues(p_state, p_missingColumnValues) {
+        // This method merges incoming updated missingColumnValues records with the missingColumnValues
+        // object in the store. Because the incoming changes can be incomplete (e.g. only contain updated
+        // records of a single column), we cannot just overwrite the store object with them.
+        // However, because of how reactivity in Vue works, we can also not simply overwrite the affected columns
+        // (i.e. keys) in the object, because that will break reactivity.
+        // The below pattern via assign sovles this problem. See here: https://v2.vuejs.org/v2/guide/reactivity.html
+        p_state.missingColumnValues = Object.assign({}, p_state.missingColumnValues, p_missingColumnValues);
 
-		// Save the new list of missing values for each given column
-		for ( const columnName in p_missingColumnValues ) {
-
-			p_state.missingColumnValues[columnName] = [...p_missingColumnValues[columnName]];
-		}
 	}
 }
 


### PR DESCRIPTION
This PR implements the version of the missing value component we have discussed in #58. The component does not detect or create missing values, it only does two things:

- for the currently relevant column names, show the missing values currently kept in the global store
- provide a UI element (button) to declare any of these values as "not missing". this will trigger an event chain and update the global store by removing this value from the array of missing values of its columnName

Writing to `missingColumnValues` in the store via the `setMissingColumnValues` mutation was not reactive, because Vue doesn't track indexed changes to Objects (see https://v2.vuejs.org/v2/guide/reactivity.html). I have replaced the store logic with an `Object.assign` statement. This will continue to work with the partial updates we are receiving from the annotation tab,

Example:
```javascript
let state_missingColumnValues = {
        "sex": ["na", "999"],
        "diagnosis": ["AD", "none", "dunno"] // AD is not a missing value, so we remove it
};
const new_missing_values = {"diagnosis": ["none", "dunno"]};
state_missingColumnValues = Object.assign({}, state_missingColumnValues, new_missing_values);
console.log(state_missingColumnValues);

// { sex: [ 'na', '999' ], diagnosis: [ 'none', 'dunno' ] }
```

Another thing I did here is to give the missing Value Component direct access to the store state. This is different from what we do for the other components and what was previously done, where we give only the pages (e.g. annotation) access to the store and then provide/inject or prop-chain the information down to the components. Two reasons why I did it this way here:

- the component already has state access for the getter (`valueDescription`)
- ~~none of the other components needs access to this information so provide / inject seems a bit overkill. similarly so would be props~~ edit: I just realized that this is not true. Other components will need this as well. So yeah, maybe we should use provide / inject
- it is easier to see what's going on while inside the component (this is a thing from the state).

But open to change to props or provide / inject.




Sidenotes:
- I'm not sure why I'm still getting white-space diffs here, I thought I had solved that by running eslint beforehand. Sorry about that.
- because this gets implemented before we have a way to "create" missing values, and because the missing values component no longer makes its own guesses, I stuck some temporary event emitter in the annotation page to create some missing values to debug with (targeted to our example.tsv file). I'll remove these once we have a way to add missing values!

Resolves #58