### PR TITLE
Implement missing values discrete

### DIFF
--- a/components/annot-age-values.vue
+++ b/components/annot-age-values.vue
@@ -39,7 +39,8 @@
 
         inject: [
 
-            "dataTable"
+            "dataTable",
+            "missingValueLabel"
         ],
 
         name: "SubNumericValidation",
@@ -189,7 +190,7 @@
                         break;
 
                     case "string":
-                        convertedValue = "missing value";
+                        convertedValue = this.missingValueLabel;
                         break;
 
                     case "isoyear": {

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -198,23 +198,16 @@
             },
 
             checkAnnotationState() {
+                // The annotation status returns true if all unique values are
+                // either assigned a mapping (e.g. have an entry in this.valueMapping) or
+                // have been declared as missing values (e.g. this.isMissingValue is true)
 
-                // 1. Begin with the assumption that there are no annotations
-                let hasAnnotation = false;
-
-                // 2. Attempt to find at least one value as having been annotated
-                for ( const columnName in this.valueMapping ) {
-
-                    // A. Check for an annotated value in the column
-                    if ( Object.values(this.valueMapping[columnName]).some(
-                        (uniqueValue) => null !== uniqueValue) ) {
-                        hasAnnotation = true;
-                        break;
-                    }
-                }
-
-                // Return whether or not there is at least one annotation
-                return hasAnnotation;
+                return this.relevantColumns.every(
+                    columnName => this.uniqueValues[columnName].every(
+                        uniqueValue => (
+                            this.valueMapping[columnName][uniqueValue] !== null) ||
+                            this.isMissingValue(columnName, uniqueValue))
+                )
             },
 
             initializeMapping() {

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -76,7 +76,8 @@
 
         inject: [
 
-            "dataTable"
+            "dataTable",
+            "isMissingValue"
         ],
 
         name: "AnnotDiscreteValues",
@@ -110,16 +111,16 @@
         computed: {
 
             displayTable() {
-
-                // Create and return table data list column name and corresponding value for all unique values in the relevant columns
+                // Create and return table data for the unique values in the relevant columns that are not missing values
                 const tableData = [];
                 for ( const columnName of this.relevantColumns ) {
                     for ( const value of this.uniqueValues[columnName] ) {
-                        tableData.push({
-
-                            column_name: columnName,
-                            raw_value: value
-                        });
+                        if ( ! this.isMissingValue(columnName, value) ) {
+                            tableData.push({
+                                column_name: columnName,
+                                raw_value: value
+                            });
+                        }
                     }
                 }
 

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -66,7 +66,7 @@
                 default() {
                     // TODO: We currently let users tell us about a missing value in the same way they annotate real values
                     // we should instead have a separate mechanism to identify missing values
-                    return ["default category", "missing value"];
+                    return ["default category", this.missingValueLabel];
                 },
                 required: true
             },
@@ -78,7 +78,8 @@
 
             "dataTable",
             "isMissingValue",
-            "missingColumnValues"
+            "missingColumnValues",
+            "missingValueLabel"
         ],
 
         name: "AnnotDiscreteValues",
@@ -191,7 +192,7 @@
 
                             if ( this.isMissingValue(columnName, transformedTable[index][columnName]) ) {
                                 // TODO: this string should be replaced by an app-wide way to designate missing values
-                                transformedTable[index][columnName] = "missing value";
+                                transformedTable[index][columnName] = this.missingValueLabel;
                             } else {
                                 transformedTable[index][columnName] = this.transformedValue(columnName, transformedTable[index][columnName]);
                             }

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -26,7 +26,8 @@
                     </template>
                     <template #cell(missing_value)="row">
                         <b-button
-                            variant="danger">
+                            variant="danger"
+                            @click="declareMissing(row.item)">
                             {{ uiText.missingValueButton }}
                         </b-button>
                     </template>
@@ -231,10 +232,14 @@
                 }
             },
 
-            removeRow(p_row) {
+            declareMissing(p_row) {
 
                 // TODO: Use this method to move unique values to the missing value category
-                return p_row;
+                console.log("please declare", p_row, "missing")
+                this.$emit('update:missingValue', {
+                    column: p_row.column_name,
+                    value: p_row.raw_value
+                });
             },
 
             transformedValue(p_columnName, p_value) {

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -227,7 +227,6 @@
             declareMissing(p_row) {
 
                 // TODO: Use this method to move unique values to the missing value category
-                console.log("please declare", p_row, "missing");
                 this.$emit('update:missingValue', {
                     column: p_row.column_name,
                     value: p_row.raw_value

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -146,20 +146,20 @@
 
         watch: {
 
-            relevantColumns(p_newColumns, p_oldColumns) {
+            relevantColumns( p_newColumns, p_oldColumns ) {
 
-                const removedColumns = p_oldColumns.filter(column => !p_newColumns.includes(column));
+                const removedColumns = p_oldColumns.filter( column => !p_newColumns.includes(column) );
 
-                if (removedColumns.length > 0) {
+                if ( removedColumns.length > 0 ) {
 
                     // There has been at least one column removed from this component's category,
                     // possibly via the annot-columns component 'remove' action
-                    for (const columnName of removedColumns) {
+                    for ( const columnName of removedColumns ) {
 
                         // We cannot just remove the key from the object with a normal
                         // JS delete operator because then Vue wouldn't be aware of it.
                         // See also: https://v2.vuejs.org/v2/api/?redirect=true#vm-delete
-                        this.$delete(this.valueMapping, columnName);
+                        this.$delete( this.valueMapping, columnName );
                     }
 
                     // TODO: Check if we need to also handle the case where a column is added

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -189,8 +189,12 @@
 
                         if ( this.relevantColumns.includes(columnName) ) {
 
-                            // TODO: If "value" is a missing value or doesn't fit the heuristic, this will currently break!
-                            transformedTable[index][columnName] = this.transformedValue(columnName, transformedTable[index][columnName]);
+                            if ( this.isMissingValue(columnName, transformedTable[index][columnName]) ) {
+                                // TODO: this string should be replaced by an app-wide way to designate missing values
+                                transformedTable[index][columnName] = "missing value";
+                            } else {
+                                transformedTable[index][columnName] = this.transformedValue(columnName, transformedTable[index][columnName]);
+                            }
                         }
                     }
                 }

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -117,7 +117,7 @@
                             (this.valueMapping[columnName][uniqueValue] !== null) ||
                             this.isMissingValue(columnName, uniqueValue) )
                     )
-                )
+                );
             },
 
             displayTable() {
@@ -226,7 +226,7 @@
             declareMissing(p_row) {
 
                 // TODO: Use this method to move unique values to the missing value category
-                console.log("please declare", p_row, "missing")
+                console.log("please declare", p_row, "missing");
                 this.$emit('update:missingValue', {
                     column: p_row.column_name,
                     value: p_row.raw_value

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -36,7 +36,7 @@
                 <!-- Button to save the annotated data of this tab to the store -->
                 <b-row>
                     <b-button
-                        :disabled="saveButtonDisabled"
+                        :disabled="!saveButtonEnabled"
                         :variant="saveButtonColor"
                         @click="applyAnnotation">
                         {{ uiText.saveButton }}
@@ -77,7 +77,8 @@
         inject: [
 
             "dataTable",
-            "isMissingValue"
+            "isMissingValue",
+            "missingColumnValues"
         ],
 
         name: "AnnotDiscreteValues",
@@ -85,8 +86,6 @@
         data() {
 
             return {
-
-                saveButtonDisabled: true,
 
                 exampleFields: [
 
@@ -110,6 +109,17 @@
 
         computed: {
 
+            saveButtonEnabled() {
+
+                return this.relevantColumns.every(
+                    columnName => this.uniqueValues[columnName].every(
+                        uniqueValue => (
+                            (this.valueMapping[columnName][uniqueValue] !== null) ||
+                            this.isMissingValue(columnName, uniqueValue) )
+                    )
+                )
+            },
+
             displayTable() {
                 // Create and return table data for the unique values in the relevant columns that are not missing values
                 const tableData = [];
@@ -130,7 +140,7 @@
             saveButtonColor() {
 
                 // Bootstrap variant color of the button to save the annotation to the data table
-                return ( !this.saveButtonDisabled ) ? "success" : "secondary";
+                return this.saveButtonEnabled ? "success" : "secondary";
             }
         },
 
@@ -140,11 +150,11 @@
 
                 const removedColumns = p_oldColumns.filter(column => !p_newColumns.includes(column));
 
-                if ( removedColumns.length > 0 ) {
+                if (removedColumns.length > 0) {
 
                     // There has been at least one column removed from this component's category,
                     // possibly via the annot-columns component 'remove' action
-                    for ( const columnName of removedColumns ) {
+                    for (const columnName of removedColumns) {
 
                         // We cannot just remove the key from the object with a normal
                         // JS delete operator because then Vue wouldn't be aware of it.
@@ -154,14 +164,10 @@
 
                     // TODO: Check if we need to also handle the case where a column is added
                 }
-
-                // Determine whether at least one annotation has occurred
-                // and set the disabled status of the save annotation button
-                this.saveButtonDisabled = !this.checkAnnotationState();
             }
         },
 
-        mounted() {
+        created() {
 
             // Initialize the mapping of all unique values as null
             this.initializeMapping();
@@ -197,19 +203,6 @@
                 });
             },
 
-            checkAnnotationState() {
-                // The annotation status returns true if all unique values are
-                // either assigned a mapping (e.g. have an entry in this.valueMapping) or
-                // have been declared as missing values (e.g. this.isMissingValue is true)
-
-                return this.relevantColumns.every(
-                    columnName => this.uniqueValues[columnName].every(
-                        uniqueValue => (
-                            this.valueMapping[columnName][uniqueValue] !== null) ||
-                            this.isMissingValue(columnName, uniqueValue))
-                )
-            },
-
             initializeMapping() {
 
                 // TODO: Revisit this once we have implemented the missing value components to make sure
@@ -243,14 +236,22 @@
             },
 
             updateMapping(p_selectedValue, p_row) {
+                // This method updates the valueMapping object.
+                // In order for Vue to detect this change and be reactive, we have to merge the new
+                // value with the existing object, one level at a time
 
-                // 1. Update the local annotation value map with the selected, new annotation value
-                this.valueMapping[p_row.column_name][p_row.raw_value] = p_selectedValue;
+                // First, we merge the inner level (e.g. the mapping for the columnName)
+                const innerUpdate = Object.assign(
+                    this.valueMapping[p_row.column_name],
+                    { [p_row.raw_value]: p_selectedValue }
+                );
 
-                // 2. Determine whether all unique values have now been mapped to something
-                // and set the disabled status of the save annotation button
-                // TODO: This might be better suited for a computed property, but this seems to break reactivity
-                this.saveButtonDisabled = !this.checkAnnotationState();
+                // Second, we merge the outer layer (e.g. the complete mapping object)
+                this.valueMapping = Object.assign(
+                    {},
+                    this.valueMapping,
+                    { [p_row.column_name]: innerUpdate }
+                );
             }
         }
     };

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -154,7 +154,7 @@
 
                     // There has been at least one column removed from this component's category,
                     // possibly via the annot-columns component 'remove' action
-                    for (const columnName of removedColumns) {
+                    for ( const columnName of removedColumns ) {
 
                         // We cannot just remove the key from the object with a normal
                         // JS delete operator because then Vue wouldn't be aware of it.

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -150,7 +150,7 @@
 
                 const removedColumns = p_oldColumns.filter(column => !p_newColumns.includes(column));
 
-                if (removedColumns.length > 0) {
+                if ( removedColumns.length > 0 ) {
 
                     // There has been at least one column removed from this component's category,
                     // possibly via the annot-columns component 'remove' action

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -150,11 +150,11 @@
 
                 const removedColumns = p_oldColumns.filter(column => !p_newColumns.includes(column));
 
-                if ( removedColumns.length > 0 ) {
+                if (removedColumns.length > 0) {
 
                     // There has been at least one column removed from this component's category,
                     // possibly via the annot-columns component 'remove' action
-                    for ( const columnName of removedColumns ) {
+                    for (const columnName of removedColumns) {
 
                         // We cannot just remove the key from the object with a normal
                         // JS delete operator because then Vue wouldn't be aware of it.

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -24,6 +24,12 @@
                             :options="options"
                             @input="updateMapping($event, row.item)" />
                     </template>
+                    <template #cell(missing_value)="row">
+                        <b-button
+                            variant="danger">
+                            {{ uiText.missingValueButton }}
+                        </b-button>
+                    </template>
                 </b-table>
 
                 <!-- Button to save the annotated data of this tab to the store -->
@@ -84,14 +90,16 @@
 
                     "column_name",
                     "raw_value",
-                    "select_an_appropriate_mapping"
+                    "select_an_appropriate_mapping",
+                    "missing_value"
                 ],
 
                 // Text for UI elements
                 uiText: {
 
                     instructions: "Annotate each unique value",
-                    saveButton: "Save Annotation"
+                    saveButton: "Save Annotation",
+                    missingValueButton: "Missing Value"
                 },
 
                 valueMapping: {}

--- a/components/annot-tab.vue
+++ b/components/annot-tab.vue
@@ -25,7 +25,8 @@
             :relevant-columns="relevantColumns"
             :unique-values="uniqueValues"
             @update:dataTable="$emit('update:dataTable', $event)"
-            @update:heuristics="$emit('update:heuristics', $event)" />
+            @update:heuristics="$emit('update:heuristics', $event)"
+            @update:missingValue="$emit('update:missingValue', $event)" />
 
     </div>
 

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -189,7 +189,7 @@
             removeMissingValue(p_event) {
 
                 // 1. Create copy of the missing values list for this column without the value to be removed
-                const missingValuesList = {}
+                const missingValuesList = {};
                 missingValuesList[p_event.column] = [];
 
                 for ( const value of this.missingColumnValues[p_event.column] ) {

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -173,7 +173,7 @@
 
                     // We do a sanity check to see if the new missing value is already listed as missing
                     // This should not happen unless a missing value is erroneously still being shown in the list of values to be annotated.
-                    if ( ! (p_event.value in columnMissingValues[p_event.column]) ) {
+                    if ( ! ( columnMissingValues[p_event.column].includes(p_event.value) ) ) {
                         columnMissingValues[p_event.column].push(p_event.value);
                     } else {
                         console.log(p_event.value, "is already in the list of missing values for column", p_event.column);

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -114,7 +114,8 @@
                 "dataDictionary",
                 "dataTable",
                 "pageData",
-                "missingColumnValues"
+                "missingColumnValues",
+                "missingValueLabel"
             ]),
 
             nextPageButtonColor() {
@@ -137,7 +138,8 @@
                 columnToCategoryMap: this.columnToCategoryMap,
                 dataDictionary: this.dataDictionary,
                 dataTable: this.dataTable,
-                missingColumnValues: this.missingColumnValues
+                missingColumnValues: this.missingColumnValues,
+                missingValueLabel: this.missingValueLabel
             };
         },
 

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -38,7 +38,8 @@
                             @remove:column="unlinkColumnFromCategory($event)"
                             @remove:missingValue="removeMissingValue($event)"
                             @update:dataTable="saveAnnotatedDataTable($event)"
-                            @update:missingColumnValues="saveMissingColumnValues($event)" />
+                            @update:missingColumnValues="saveMissingColumnValues($event)"
+                            @update:missingValue="addMissingValue($event)" />
                     </b-card-text>
 
                 </b-tab>
@@ -151,18 +152,44 @@
                 pageName: "download",
                 enable: this.isDataAnnotated
             });
-
-            // TODO: remove this, just a temporary way to add any missing values to the store
-            const missingLists = {"sex": [0, 1]};
-            this.saveMissingColumnValues(missingLists);
         },
 
         methods: {
+            addMissingValue(p_event) {
+                // This method expects an event object with a `column` and a `value` key.
+                // It will merge the new missing value with the existing missing value array for
+                // the `column` name and save it to the global store
+
+                let columnMissingValues = {};
+
+                if ( Object.keys(this.missingColumnValues).includes(p_event.column) ) {
+                    // If missing values are already listed for this column, we add the new value to them
+                    // We will reconstruct the array of missing values from the store because we don't want to copy it directly
+                    // TODO: an alternative approach would be to use deepcopy from https://github.com/lodash/lodash
+                    columnMissingValues[p_event.column] = [];
+                    for ( const value of this.missingColumnValues[p_event.column] ) {
+                        columnMissingValues[p_event.column].push(value);
+                    }
+
+                    // We do a sanity check to see if the new missing value is already listed as missing
+                    // This should not happen unless a missing value is erroneously still being shown in the list of values to be annotated.
+                    if ( ! (p_event.value in columnMissingValues[p_event.column]) ) {
+                        columnMissingValues[p_event.column].push(p_event.value);
+                    } else {
+                        console.log(p_event.value, "is already in the list of missing values for column", p_event.column);
+                    }
+
+                } else {
+                    // Because no missing values were listed in the store for this column before, we just save the new one
+                    columnMissingValues[p_event.column] = [p_event.value];
+                }
+                this.$store.dispatch("saveMissingColumnValues", columnMissingValues);
+            },
 
             removeMissingValue(p_event) {
 
                 // 1. Create copy of the missing values list for this column without the value to be removed
-                const missingValuesList = {};
+                const missingValuesList = {}
                 missingValuesList[p_event.column] = [];
 
                 for ( const value of this.missingColumnValues[p_event.column] ) {

--- a/store/index.js
+++ b/store/index.js
@@ -117,6 +117,9 @@ export const state = () => ({
 
     // Annotation page-specific fields
 
+    // The string label applied to values designated as "missing values" when the data are annotated.
+    missingValueLabel: "missing value",
+
     // Keeps track of textual- and component-related information for the annotation of each category
     // See action nuxtServerInit() for initialization code
     annotationDetails: [],
@@ -181,7 +184,7 @@ export const actions = {
 				category: "Sex",
 				dataType: "categorical",
                 explanation: "This is an explanation for how to annotate sex.",
-				options: ["male", "female", "other", "missing value"],
+				options: ["male", "female", "other"],
 				specializedComponent: "annot-discrete-choices"
 			},
 			{

--- a/store/index.js
+++ b/store/index.js
@@ -569,7 +569,7 @@ export const getters = {
 
         // 0. If we do not have a data dictionary then the value description is undefined (e.g. 'null')
         let valueDescription = null;
-        console.log("getting description for", p_columnName, p_value)
+        console.log("getting description for", p_columnName, p_value);
 
         // 1. Find the description for this column's value in the data dictionary
         if ( null !== p_state.dataDictionary.original && Object.keys(p_state.dataDictionary.original).includes(p_columnName) ) {

--- a/store/index.js
+++ b/store/index.js
@@ -544,18 +544,32 @@ export const getters = {
 	isMissingValue: (p_state) => (p_columnName, p_value) => {
     // Checks if a column-value combination is stored in the missingColumnValues object
     // and returns true if it is, false otherwise
+    // if no records are stored for the entire p_columnName, then also returns false
 
 		if ( !Object.keys(p_state.missingColumnValues).includes(p_columnName) ) {
-			console.log(`WARNING: Could not find '${p_columnName}' in p_state.missingColumnValues`);
+			console.log(`WARNING: Could not find '${p_columnName}' in p_state.missingColumnValues. Will treat as not missing.`);
+            return false;
 		}
 
 		return ( p_state.missingColumnValues[p_columnName].includes(p_value) );
 	},
 
+    getMissingValuesColumn: (p_state) => (p_columnName) => {
+        // For a given column name returns the array of missing values the state knows about
+        // or returns null if no missing values are stored for this column name
+
+        if ( !Object.keys(p_state.missingColumnValues).includes(p_columnName) ) {
+            return null;
+        } else {
+            return p_state.missingColumnValues[p_columnName];
+        }
+    },
+
     valueDescription: (p_state) => (p_columnName, p_value) => {
 
         // 0. If we do not have a data dictionary then the value description is undefined (e.g. 'null')
         let valueDescription = null;
+        console.log("getting description for", p_columnName, p_value)
 
         // 1. Find the description for this column's value in the data dictionary
         if ( null !== p_state.dataDictionary.original && Object.keys(p_state.dataDictionary.original).includes(p_columnName) ) {


### PR DESCRIPTION
This PR implements the interface and logic to declare missing values in the discrete-values component (atm used for the sex category).

Criteria from the issue were:
Accept when:

- [x] I have an interface element that can be used to designate a value as missing
- [x] using the interface element causes this value to be removed from the list of values to be annotated
- [x] using the interface element also causes the value to be stored in the global store in the list/object for "missing values"
- [x] the value will then be shown by the corresponding missing value component
- [x] when the value is removed from the list of missing values via the missing-value-component, it shows up again in my list of values to annotate
- [ ] ~~when that happens, the mapping of the value should be empty and the annotation status should be consider incomplete~~
- [x] this will also be reflected in computing the annotation status of the category
- [x] when the annotation is "saved" with missing values labeled, these values will be annotated as "missing" or something consistent like that.

The main addition here was making the state check for the "save annotation" button a computed property and turn all of its dependencies (e.g. `this.valueMapping`) reactive.



Resolves #120 