### PR TITLE
Fixes for unique explanation component ID and client-only tags

### DIFF
--- a/components/annot-explanation.vue
+++ b/components/annot-explanation.vue
@@ -5,12 +5,12 @@
         <b-card no-body class="mb-1">
 
             <b-card-header class="p-1" header-tag="header" role="tab">
-                <b-button block v-b-toggle.accordion-explanation variant="info">
+                <b-button block v-b-toggle="'accordion-explanation-' + index" variant="info">
                     {{ uiText.cardTitle }}
                 </b-button>
             </b-card-header>
 
-            <b-collapse id="accordion-explanation" accordion="my-accordion" role="tabpanel">
+            <b-collapse :id="'accordion-explanation-' + index" accordion="my-accordion" role="tabpanel">
                 <b-card-body>
                     <b-card-text>{{ explanation }}</b-card-text>
                 </b-card-body>
@@ -32,6 +32,12 @@
                 
                 type: String,
                 default: "No explanation has been provided yet."
+            },
+
+            index: {
+
+                type: Number,
+                default: 0
             }
         },
 

--- a/components/annot-tab.vue
+++ b/components/annot-tab.vue
@@ -3,7 +3,7 @@
     <div>
 
         <!-- Explanation text for this annotation tab -->
-        <annot-explanation :explanation="details.explanation" />
+        <annot-explanation :explanation="details.explanation" :index="details.id" />
 
         <!-- Lists all the columns linked to the category of this annotation tab -->
         <annot-columns

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -17,8 +17,7 @@
             I forced this block to be rendered client-side only for now and that fixed it for now
             See: https://nuxtjs.org/docs/features/nuxt-components/#the-client-only-component
         -->
-        <no-ssr>
-
+        <client-only>
             <!-- This gives us built-in keyboard navigation! -->
             <b-tabs
                 card
@@ -43,9 +42,8 @@
 
                 </b-tab>
 
-
             </b-tabs>
-        </no-ssr>
+        </client-only>
 
         <b-row>
 


### PR DESCRIPTION
This PR is for two small fixes. 

The first is to supply the explanation component on annotation tabs with a unique ID so has consistent behavior - each explanation component on each tab acts like it is a separate object with its own expansion status.

The second is to replace the old `no-ssr` tag that is currently being used to overcome the duplicate annotation tab bug that @surchs discovered. The suggested `client-only` tag has replaced it. There is no discernible difference other than the deprecated `no-ssr` tag warning disappearing from the debug console.

Resolves #116 
Resolves #109