### PR TITLE
Annotation tool now outputs JSON files reflecting the annotated table

### DIFF
--- a/components/annot-tab.vue
+++ b/components/annot-tab.vue
@@ -71,7 +71,7 @@
 
             ...mapGetters([
 
-                "getColumnOfCategory"
+                "getColumnsOfCategory"
             ]),
 
             filteredDataTable() {
@@ -161,7 +161,8 @@
             this.category = this.details.category;
 
             // 2. Get column marked as subject ID
-            this.idField = this.getColumnOfCategory("Subject ID");
+            // NOTE: Subject ID is only allowed one column
+            this.idField = this.getColumnsOfCategory("Subject ID")[0];
         }
     };
 

--- a/components/annot-tool-group.vue
+++ b/components/annot-tool-group.vue
@@ -66,9 +66,6 @@
 
 <script>
 
-    // Allows for reference to store data by creating simple, implicit getters
-    import { mapGetters } from "vuex";
-
     export default {
 
         props: {
@@ -116,14 +113,6 @@
 
                 subjectAvailability: {}
             };
-        },
-
-        computed: {
-
-            ...mapGetters([
-
-                "getColumnOfCategory"
-            ])
         },
 
         watch: {

--- a/components/file-selector.vue
+++ b/components/file-selector.vue
@@ -76,8 +76,15 @@
 
                         complete: results => {
 
+                            // I. Returned results inlcude data and filename
+                            const myJson = {
+
+                                data: results.data,
+                                filename: this.fileInput.name
+                            };
+
                             // I. Send the file data to the store to be processed and saved
-                            this.$emit("file-selected", results.data);
+                            this.$emit("file-selected", myJson);
                         }
                     });
                 }
@@ -85,7 +92,7 @@
                 else if ( this.knownContentTypes["json"] === this.contentType ) {
 
                     // I. Reference to this json object in this component's data
-                    let myJson;
+                    let myJson = {};
 
                     // II. Create a file reader object for reading the json file contents
                     const reader = new FileReader();
@@ -94,9 +101,12 @@
                     reader.onload = e => {
 
                         // a. Save a reference to the loaded contents
-                        myJson = e.target.result;
+                        myJson.data = e.target.result;
 
-                        // b. Send the file data to any parent/listener
+                        // b. Store the filename
+                        myJson.filename = this.fileInput.name;
+
+                        // c. Send the file data to any parent/listener
                         this.$emit("file-selected", myJson);
                     };
 

--- a/pages/download.vue
+++ b/pages/download.vue
@@ -78,7 +78,6 @@
 
             ...mapGetters([
 
-                "getColumnsOfCategory",
                 "isDataAnnotated"
             ]),
 

--- a/pages/download.vue
+++ b/pages/download.vue
@@ -26,7 +26,8 @@
                 <b-button
                     class="float-right"
                     :disabled="!isDataAnnotated"
-                    :variant="downloadButtonColor">
+                    :variant="downloadButtonColor"
+                    @click="downloadAnnotatedData">
                     {{ uiText.downloadButton }}
                 </b-button>
             </b-col>
@@ -43,6 +44,9 @@
     import { mapState } from "vuex";
     import { mapGetters } from "vuex";
 
+    // Saves file to user's computer
+    import { saveAs } from "file-saver";
+
     export default {
 
         name: "DownloadPage",
@@ -50,6 +54,10 @@
         data() {
 
             return {
+
+                categoryToColumnMap: {},
+
+                jsonSpacing: 4,
 
                 // Size of the file display textboxes
                 textArea: {
@@ -63,7 +71,6 @@
 
                     downloadButton: "Download Annotated Data"
                 }
-
             };
         },
 
@@ -71,13 +78,28 @@
 
             ...mapGetters([
 
+                "getColumnsOfCategory",
                 "isDataAnnotated"
             ]),
 
             ...mapState([
 
-                "dataTable"
+                "columnToCategoryMap",
+                "dataTable",
+                "missingValueLabel",
+                "toolGroups"
             ]),
+
+            datasetName() {
+
+                // Dataset name is original data table filename with no extension
+                return this.dataTable.filename.split(".").slice(0, -1).join(".");
+            },
+
+            defaultOutputFilename() {
+
+                return `${this.datasetName}_annotated_${Date.now()}.json`;
+            },
 
             downloadButtonColor() {
 
@@ -88,32 +110,103 @@
 
         mounted() {
 
-            // Set the current page
+            // 1. Set the current page
             this.$store.dispatch("setCurrentPage", "download");
+
+            // 2. Create a reverse of the column to category map in the store
+            this.refreshCategoryToColumnMap();
         },
 
         methods: {
 
-            saveFile() {
+            downloadAnnotatedData() {
 
-                // 1. Create a blob out of the annotated table data
-                const data = JSON.stringify(this.dataTable.annotated);
-                const blob = new Blob([data], {type: "text/plain"});
+                // 1. Format the annotated table into propietary JSON format
+                const jsonData = this.transformAnnotatedTableToJSON();
 
-                // 2. Create an anchor tag in memory linked to the blob
-                const pseudoAnchor = document.createElement("a");
-                pseudoAnchor.download = "annotated_data.json";
-                pseudoAnchor.href = window.URL.createObjectURL(blob);
-                pseudoAnchor.dataset.downloadurl = [
-                    "text/json",
-                    pseudoAnchor.download,
-                    pseudoAnchor.href
-                ].join(':');
+                // 2. Open file dialog to prompt the user to name it and
+                // download it to their location of choice
+                this.fileSaverSaveAs(jsonData);
+            },
 
-                // 3. Dispatch a mouse click event on the in-memory anchor tag
-                const pseudoClickEvent = document.createEvent("MouseEvents");
-                pseudoClickEvent.initEvent("click", true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-                pseudoAnchor.dispatchEvent(pseudoClickEvent);
+            fileSaverSaveAs(p_jsonData) {
+
+                var blob = new Blob([JSON.stringify(p_jsonData, null, this.jsonSpacing)], {type: "text/plain;charset=utf-8"});
+                saveAs(blob, this.defaultOutputFilename);
+            },
+
+            refreshCategoryToColumnMap() {
+
+                this.categoryToColumnMap = {};
+                for ( const column in this.columnToCategoryMap ) {
+
+                    const myCategory = this.columnToCategoryMap[column];
+
+                    // Categories may have multiple columns associated with them
+                    if ( !Object.keys(this.categoryToColumnMap).includes(myCategory) ) {
+                        this.categoryToColumnMap[myCategory] = [];
+                    }
+                    this.categoryToColumnMap[myCategory].push(column);
+                }
+            },
+
+            transformAnnotatedTableToJSON() {
+
+                // Transform the annotated data table into a new subject-centric JSON format for the output file
+                return {
+
+                    name: this.datasetName,
+                    type: "dataset",
+                    subjects: this.dataTable.annotated.map(row => this.transformAnnotatedRowToSubjectJSON(row))
+                };
+            },
+
+            transformAnnotatedRowToSubjectJSON(p_row) {
+
+                // 0. Determine all columns of the original data that have been categorized
+                const availableCategories = Object.values(this.columnToCategoryMap);
+
+                // 1. Create the new subject object, key by key
+                const subjectJSON = {};
+
+                // NOTE: Currently only one column is allowed for subject ID, age, and sex
+
+                // A. Subject ID - This categorization is required in order to
+                // proceed to the annotation page
+                subjectJSON["id"] = p_row[this.categoryToColumnMap["Subject ID"][0]];
+
+                // B. Age
+                if ( availableCategories.includes("Age") ) {
+                    subjectJSON["age"] = p_row[this.categoryToColumnMap["Age"][0]];
+                }
+
+                // C. Sex
+                if ( availableCategories.includes("Sex") ) {
+                    subjectJSON["sex"] = p_row[this.categoryToColumnMap["Sex"][0]];
+                }
+
+                // D. Diagnoses
+                if ( availableCategories.includes("Diagnosis") ) {
+
+                    // I. Create a list of values from the diagnosis columns in the annotated table row
+                    subjectJSON["diagnosis"] = this.categoryToColumnMap["Diagnosis"].map(column => p_row[column])
+                        .filter(value => this.missingValueLabel !== value);
+                }
+
+                // E. Assessment tool group availability for this subject
+                subjectJSON["assessment_tool"] = [];
+                for ( const groupName in this.toolGroups ) {
+
+                    // Availability suffix string should be in store?
+                    const columnName = groupName + "_avail";
+
+                    // Only include tool group names that are available for this subject
+                    if ( true === p_row[columnName] ) {
+                        subjectJSON["assessment_tool"].push(columnName);
+                    }
+                }
+
+                return subjectJSON;
             }
         }
     };

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -170,7 +170,8 @@
                 // NOTE: Defaults to json for now
                 this.$store.dispatch("saveDataDictionary", {
 
-                    data: ( "none" === p_fileData ) ? null : p_fileData,
+                    data: ( "none" === p_fileData ) ? null : p_fileData.data,
+                    filename: ( "none" === p_fileData ) ? "" : p_fileData.filename,
                     fileType: "json"
                 });
             },
@@ -181,7 +182,8 @@
                 // NOTE: Defaults to tsv for now
                 this.$store.dispatch("saveDataTable", {
 
-                    data: ( null === p_fileData || 0 === p_fileData.length ) ? null : p_fileData,
+                    data: ( null === p_fileData || 0 === p_fileData.data.length ) ? null : p_fileData.data,
+                    filename: ( null === p_fileData ) ? "" : p_fileData.filename,
                     fileType: "tsv"
                 });
 

--- a/store/index.js
+++ b/store/index.js
@@ -59,6 +59,9 @@ export const state = () => ({
         // List of data table's columns
         columns: [],
 
+        // File name of the data table tsv file
+        filename: "",
+
         // File type of the original data table file
         fileType: "",
 
@@ -73,6 +76,9 @@ export const state = () => ({
     // Data dictionary (i.e. participants.json)
 
     dataDictionary: {
+
+        // File names of the data dictionary json file
+        filename: "",
 
         // File type of the original data dictionary file
         fileType: "",
@@ -128,9 +134,9 @@ export const state = () => ({
     // See action nuxtServerInit() for initialization code
     annotationDetails: [],
 
-      // Stores a list of (potentially) missing values for each column. This is determined in the missing-values
-      // components on the annotation page, and then amended by the user as they see fit
-      missingColumnValues: {},
+    // Stores a list of (potentially) missing values for each column. This is determined in the missing-values
+    // components on the annotation page, and then amended by the user as they see fit
+    missingColumnValues: {},
 
     // Keeps track of named assessment tool groups and their associated tools (e.g. columns in the data table)
     toolGroups: {}
@@ -440,7 +446,10 @@ export const mutations = {
         // 1. Save the new data dictionary to state data
         p_state.dataDictionary.original = p_newFileData.formattedData;
 
-        // 2. Save the file type of the new data dictionary
+        // 2. Save the file name of the data dictionary json file
+        p_state.dataDictionary.filename = p_newFileData.filename;
+
+        // 3. Save the file type of the new data dictionary
         p_state.dataDictionary.fileType = p_newFileData.fileType;
     },
 
@@ -449,13 +458,16 @@ export const mutations = {
         // 1. Save the new tsv row dictionary list to state data
         p_state.dataTable.original = p_newFileData.formattedData;
 
-        // 2. Save the file type of the new data table
+        // 2. Save the file name of the tsv file
+        p_state.dataTable.filename = p_newFileData.filename;
+
+        // 3. Save the file type of the new data table
         p_state.dataTable.fileType = p_newFileData.fileType;
 
-        // 3. Save a list of the columns of this data table
+        // 4. Save a list of the columns of this data table
         p_state.dataTable.columns = p_newFileData.columns;
 
-        // 4. Make the annotated data a copy of the original
+        // 5. Make the annotated data a copy of the original
         p_state.dataTable.annotated = structuredClone(p_state.dataTable.original);
     },
 
@@ -588,19 +600,18 @@ export const getters = {
         return columnDescription;
     },
 
-    getColumnOfCategory: (p_state) => (p_category) => {
+    getColumnsOfCategory: (p_state) => (p_category) => {
 
-        // If it exists in the map, retrieve the column assigned this category
-        let columnName = "";
+        // If it exists in the map, retrieve the column(s) assigned this category
+        let columns = [];
 
         for ( const column in p_state.columnToCategoryMap ) {
             if ( p_category === p_state.columnToCategoryMap[column] ) {
-                columnName = column;
-                break;
+                columns.push(column);
             }
         }
 
-        return columnName;
+        return columns;
     },
 
     getGroupOfTool: (p_state) => (p_tool) => {


### PR DESCRIPTION
Primary changes:

- Upon clicking the 'download' button on the Download page produces a new subject-centric JSON format of the data in the annotated table (as described in #7 and #162)
- The new JSON is then downloaded to the user's browser downloads folder with the filename: 
`<original data table tsv filename>_annotated_<current timestamp>.json`

Other related changes:

- Filenames of data table and data dictionary files are stored in the store after upload on the landing page
- Fix for getter `getColumnOfCategory` --> `getColumnsOfCategory`