### PR TITLE
Fix for categorical double save bug on annotation page

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,3 +15,4 @@ jobs:
         with:
           build: npm run build
           start: npm start
+          component: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,22 +3,22 @@ name: Cypress Tests
 on: [push]
 
 jobs:
-    cypress-run:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-                uses: actions/checkout@v2
-            # Install NPM dependencies, cache them correctly
-            # and run all Cypress tests
-            - name: Run End to End tests
-                uses: cypress-io/github-action@v4
-                with:
-                    build: npm run build
-                    start: npm start
-            - name: Run Component tests 🧪
-                uses: cypress-io/github-action@v4
-                with:
-                    # we have already installed everything
-                    install: false
-                    # to run component tests we need to use "component: true"
-                    component: true
+  cypress-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      # Install NPM dependencies, cache them correctly
+      # and run all Cypress tests
+      - name: Run End to End tests
+        uses: cypress-io/github-action@v4
+        with:
+          build: npm run build
+          start: npm start
+      - name: Run Component tests 🧪
+        uses: cypress-io/github-action@v4
+        with:
+          # we have already installed everything
+          install: false
+          # to run component tests we need to use "component: true"
+          component: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,16 +3,22 @@ name: Cypress Tests
 on: [push]
 
 jobs:
-  cypress-run:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      # Install NPM dependencies, cache them correctly
-      # and run all Cypress tests
-      - name: Cypress run
-        uses: cypress-io/github-action@v4
-        with:
-          build: npm run build
-          start: npm start
-          component: true
+    cypress-run:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+                uses: actions/checkout@v2
+            # Install NPM dependencies, cache them correctly
+            # and run all Cypress tests
+            - name: Run End to End tests
+                uses: cypress-io/github-action@v4
+                with:
+                    build: npm run build
+                    start: npm start
+            - name: Run Component tests 🧪
+                uses: cypress-io/github-action@v4
+                with:
+                    # we have already installed everything
+                    install: false
+                    # to run component tests we need to use "component: true"
+                    component: true

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -103,6 +103,8 @@
                     "missing_value"
                 ],
 
+                // This field is used to ensure the save annotation button is
+                // disabled after new annotation data has been saved by the user
                 hasNewAnnotation: false,
 
                 // Text for UI elements
@@ -204,20 +206,18 @@
                 // 1. Create a local copy of the annotated table for transformation
                 const transformedTable = structuredClone(this.dataTable.annotated);
 
-                // 2. Transform all values in columns categorized as 'age' columns
-                for ( let index = 0; index < transformedTable.length; index++ ) {
-                    for ( const columnName in transformedTable[index] ) {
+                // 2. Transform all values in columns categorized as columns selected for this discrete choices component
+                for ( let index = 0; index < this.dataTable.original.length; index++ ) {
 
-                        if ( this.relevantColumns.includes(columnName) ) {
+                    for ( const columnName of this.relevantColumns ) {
 
-                            if ( this.isMissingValue(columnName, transformedTable[index][columnName]) ) {
+                        if ( this.isMissingValue(columnName, transformedTable[index][columnName]) ) {
 
-                                // TODO: this string should be replaced by an app-wide way to designate missing values
-                                transformedTable[index][columnName] = this.missingValueLabel;
-                            } else {
+                            // TODO: this string should be replaced by an app-wide way to designate missing values
+                            transformedTable[index][columnName] = this.missingValueLabel;
+                        } else {
 
-                                transformedTable[index][columnName] = this.transformedValue(columnName, this.getOriginalColumnValue(transformedTable[index]["participant_id"], columnName));
-                            }
+                            transformedTable[index][columnName] = this.transformedValue(columnName, this.dataTable.original[index][columnName]);
                         }
                     }
                 }
@@ -285,7 +285,8 @@
                     { [p_row.column_name]: innerUpdate }
                 );
 
-                // 3. Indicate that there a new annotation value has been entered
+                // 3. Indicate that there a new annotation value has been
+                // entered, ensuring the save annotation button is enabled
                 this.hasNewAnnotation = true;
             }
         }

--- a/cypress/component/annot-discrete-choices.cy.js
+++ b/cypress/component/annot-discrete-choices.cy.js
@@ -1,0 +1,154 @@
+import AnnotDiscreteChoices from "./../../components/annot-discrete-choices.vue"; // import the component to test
+
+// Props definitions
+
+const props = {
+
+    options: ["male", "female", "other"],
+    relevantColumns: ["sex"],
+    title: "Sex",
+    uniqueValues: { "sex": ["M", "F"] }
+};
+
+// Injects
+
+const injectMixin = {
+
+    data: function() {
+
+        return {
+
+            dataTable: {
+
+                original: [
+                    {
+                        "participant_id": "sub-718211",
+                        "age": 28.4,
+                        "sex": "M",
+                        "group": "UD",
+                        "group_dx": "MDD",
+                        "number_comorbid_dx": 0,
+                        "medload": 0,
+                        "iq": 117.66,
+                        "session": 1
+                    },
+                    {
+                        "participant_id": "sub-718213",
+                        "age": 24.6,
+                        "sex":	"F",
+                        "group": "UD",
+                        "group_dx": "MDD",
+                        "number_comorbid_dx": 0,
+                        "medload": 0,
+                        "iq": 109.08,
+                        "session": 1
+                    }
+                ],
+
+                annotated: [
+                    {
+                        "participant_id": "sub-718211",
+                        "age": 28.4,
+                        "sex": "M",
+                        "group": "UD",
+                        "group_dx": "MDD",
+                        "number_comorbid_dx": 0,
+                        "medload": 0,
+                        "iq": 117.66,
+                        "session": 1
+                    },
+                    {
+                        "participant_id": "sub-718213",
+                        "age": 24.6,
+                        "sex":	"F",
+                        "group": "UD",
+                        "group_dx": "MDD",
+                        "number_comorbid_dx": 0,
+                        "medload": 0,
+                        "iq": 109.08,
+                        "session": 1
+                    }
+                ]
+            },
+
+            missingColumnValues: {},
+            missingValueLabel: "missing value"
+        };
+    },
+
+    methods: {
+
+        isMissingValue: (p_columnName, p_value) => false,
+
+        getOriginalColumnValue: (p_state) => (p_subjectID, p_columnName) => {
+
+            for ( let index = 0; index < p_state.dataTable.original.length; index++ ) {
+
+                if ( p_subjectID === p_state.dataTable.original[index]["participant_id"] ) {
+
+                    return p_state.dataTable.original[index][p_columnName];
+                }
+            }
+
+            return null;
+        }
+    }
+};
+
+describe("annot-discrete-choices.cy.js", () => {
+
+    it("Selects discrete choices; tests save button status", () => {
+
+        // 1. Mount the component
+        cy.mount(AnnotDiscreteChoices, {
+
+            propsData: props,
+            mixins: [injectMixin],
+            plugins: ["bootstrap-vue", "vue-select"]
+        });
+
+        // 2. Assert 'Save Annotation' button is disabled
+        cy.assertButtonStatus("save-button-" + props.title, false);
+
+        // 3. Select annotation choices for 'Sex' column values
+        cy.get("[data-cy='discrete-select-" + props.title + "-0']").click().type(props.options[0] + "{enter}");
+        cy.get("[data-cy='discrete-select-" + props.title + "-1']").click().type(props.options[1] + "{enter}");
+
+        // 4. Assert 'Save Annotation' button is enabled
+        cy.assertButtonStatus("save-button-" + props.title, true);
+    });
+
+    it("Selects discrete choices and saves annotation; tests save button status", () => {
+
+        // 1. Mount the component
+        cy.mount(AnnotDiscreteChoices, {
+
+            propsData: props,
+            mixins: [injectMixin],
+            plugins: ["bootstrap-vue", "vue-select"]
+        });
+
+        // 2. Assert 'Save Annotation' button is disabled
+        cy.assertButtonStatus("save-button-" + props.title, false);
+
+        // 3. Select annotation choices for 'Sex' column values
+        cy.get("[data-cy='discrete-select-" + props.title + "-0']").click().type(props.options[0] + "{enter}");
+        cy.get("[data-cy='discrete-select-" + props.title + "-1']").click().type(props.options[1] + "{enter}");
+
+        // 4. Assert 'Save Annotation' button is enabled
+        cy.assertButtonStatus("save-button-" + props.title, true);
+
+        // 5. Click on the 'Save Annotation' button
+        cy.get("[data-cy='save-button-" + props.title + "']")
+            .click();
+
+        // 6. Assert 'Save Annotation' button is disabled
+        cy.assertButtonStatus("save-button-" + props.title, false);
+    });
+});
+
+// Plugins
+// args.global = args.global || {}
+// args.global.plugins = args.global.plugins || []
+// args.global.plugins.push(createPinia())
+// args.global.plugins.push(createI18n())

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -36,12 +36,22 @@ Cypress.Commands.add("appSetup", () => {
     cy.viewport("macbook-13");
 });
 
-Cypress.Commands.add("assertNextPageAccess", (p_pageName, p_enabled) => {
+Cypress.Commands.add("assertButtonStatus", (p_buttonName, p_enabled) => {
 
     let chainer = ( p_enabled ) ? "not.have.class" : "have.class";
 
-    cy.get("[data-cy='menu-item-" + p_pageName + "'] a")
+    cy.get("[data-cy='" + p_buttonName + "']")
         .should(chainer, "disabled");
+});
+
+Cypress.Commands.add("assertNextPageAccess", (p_pageName, p_enabled, p_checkMenu=true) => {
+
+    let chainer = ( p_enabled ) ? "not.have.class" : "have.class";
+
+    if ( p_checkMenu ) {
+        cy.get("[data-cy='menu-item-" + p_pageName + "'] a")
+            .should(chainer, "disabled");
+    }
     cy.get("[data-cy='button-nextpage']")
         .should(chainer, "disabled");
 });

--- a/cypress/support/component.js
+++ b/cypress/support/component.js
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands';
+import "./commands";
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
@@ -25,3 +25,10 @@ Cypress.Commands.add('mount', mount);
 
 // Example use:
 // cy.mount(MyComponent)
+
+// Import styles
+import "./../../assets/css/main.css";
+
+// Import plugins
+import "./../../plugins/bootstrap-vue";
+import "./../../plugins/vue-select";

--- a/store/index.js
+++ b/store/index.js
@@ -627,6 +627,20 @@ export const getters = {
         return toolGroup;
     },
 
+    getOriginalColumnValue: (p_state) => (p_subjectID, p_columnName) => {
+
+        for ( let index = 0; index < p_state.dataTable.original.length; index++ ) {
+
+            if ( p_subjectID === p_state.dataTable.original[index]["participant_id"] ) {
+
+                return p_state.dataTable.original[index][p_columnName];
+            }
+        }
+
+        return null;
+    },
+
+
     isColumnLinkedToCategory: (p_state) => (p_matchData) => {
 
         // Check to see if the given column has been linked to the given category


### PR DESCRIPTION
@surchs Opening this up as the fix for bug #176 is ready in the related commit.

[Edit: I will be following this commit up with a component test for `annot-discrete-choices`, so hold up on this PR review until that commit is in.)

There is also a question of establishing a UI paradigm regarding the 'Save Annotation' button. See below.

**Fix description**

The issue lay in how the `applyAnnotation` function in `annot-discrete-choices.vue` sets new values. Once a new annotation value is saved it is set in the annotated table and we can no longer rely on the value in that table to help us find a newly set value in the `valueMapping` object. The latter is updated every time a new selection is made by the user (via the `updateMapping` function).

So, what was needed is 1 (or possibly 2) additions to our code. The first is a utility getter function placed in the store `getOriginalColumnValue` that takes a subject ID and looks to get the original value of its column. This allows us to correctly find the key in `valueMapping` for the newly-selected annotation value.

The second piece is the ability to flag the enabled status of the 'Save Annotation' button as to whether or not a new annotation value has been entered into the interface. This is initially set to `false` on component created (see `initializeMapping`) and is flagged to `true` once `updateMapping` is called. Once a user has saved the annotation, the flag is once again set to `false`. The `saveButtonEnabled` value that is tied to the enabled status of the button makes use of this new flag.

Let me know what you think of both pieces of the implementation.