### PR TITLE
File select cancellation fix + condition cleanup

### DIFF
--- a/components/file-selector.vue
+++ b/components/file-selector.vue
@@ -50,6 +50,7 @@
 
             fileName() {
 
+                // null - No file has been selected yet
                 return ( null === this.fileInput ) ? "" : this.fileInput.name;
             }
         },
@@ -58,14 +59,14 @@
 
             onFileSelected(p_event){
 
-                // 1. Save the file name
-                this.fileInput = p_event.target.files[0];
+                // 0. Do nothing if no file selected (e.g. file dialog cancellation)
+                if ( 0 === p_event.target.files.length ) {
 
-                // A. If no file selected, emit a no file selected message
-                if ( "undefined" === typeof this.fileInput ) {
-                    this.$emit("file-selected", "none");
                     return;
                 }
+
+                // 1. Save the file name
+                this.fileInput = p_event.target.files[0];
 
                 // 2. Parse the whole file and save the lines
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -173,8 +173,8 @@
                 // NOTE: Defaults to json for now
                 this.$store.dispatch("saveDataDictionary", {
 
-                    data: ( "none" === p_fileData ) ? null : p_fileData.data,
-                    filename: ( "none" === p_fileData ) ? "" : p_fileData.filename,
+                    data: p_fileData.data,
+                    filename: p_fileData.filename,
                     fileType: "json"
                 });
             },
@@ -185,8 +185,8 @@
                 // NOTE: Defaults to tsv for now
                 this.$store.dispatch("saveDataTable", {
 
-                    data: ( null === p_fileData || 0 === p_fileData.data.length ) ? null : p_fileData.data,
-                    filename: ( null === p_fileData ) ? "" : p_fileData.filename,
+                    data: ( 0 === p_fileData.data.length ) ? null : p_fileData.data,
+                    filename: p_fileData.filename,
                     fileType: "tsv"
                 });
 


### PR DESCRIPTION
This bug fix addresses issue #194. Before, selecting a data table file (`participants.tsv`) and then attempting to select a second file but instead cancelling in the file select dialog resulted in a JS error and page crash.

Once this crash was initially addressed, it also revealed that the code would wipe the first data table selection (as well as its filename and file preview in the UI). 

Neither of these issues occurred for the data dictionary file selection.

Expected behavior:

- [ ] Page does not crash when second data table file selection attempt is cancelled
- [ ] Currently selected data table is not wiped but remains after file select cancellation
- [ ] Data dictionary file selection maintains consistent behavior with data table file selection

The above was addressed by creating a cleaner check against file select event's file data and by not resetting the file data variable if no new file has been selected. (See `onFileSelected` in `file-selector.vue`.)

I also cleaned up some conditional checks for possible values of the file data variable `fileInput` in `file-selector`.  It's either `null` or has a valid value. And I removed the file-select event propagating back up to `index.vue` that was using the string `"none"` to indicate a file selection cancellation.