### PR TITLE
Refactor of category-select-table component

### DIFF
--- a/components/category-select-table.vue
+++ b/components/category-select-table.vue
@@ -1,58 +1,59 @@
 <template>
 
-    <b-container fluid>
-
-        <!-- Heading for category select component -->
-        <b-row>
-            <h3>{{ title }}</h3>
-        </b-row>
-
-        <!-- Instructions prompting the user how to link categories and columns -->
-        <b-row>
-            <p class="instructions-text">
-                {{ instructions }}
-            </p>
-        </b-row>
+    <div>
 
         <!-- Category selection table -->
-        <b-row>
-            <b-table
-                outlined
-                selectable
-                head-variant="dark"
-                :items="categoryTable"
-                @row-selected="selectCategory"
-                select-mode="single"
-                selected-variant=""
-                :tbody-tr-class="styleTableRow"
-                thead-class="hidden" />
+        <b-row class="no-padding-row">
+
+            <b-col cols="12" class="no-padding-col">
+                <b-table
+                    outlined
+                    selectable
+                    head-variant="dark"
+                    :items="categoryTable"
+                    @row-selected="selectCategory"
+                    select-mode="single"
+                    selected-variant=""
+                    :tbody-tr-class="styleTableRow"
+                    thead-class="hidden" />
+                <b-icon-plus-circle
+                    style="display: block; margin-left: auto; margin-right: auto;"
+                    @click="addCustomCategory" />
+            </b-col>
         </b-row>
 
-    </b-container>
+    </div>
 
 </template>
 
 <script>
 
+    // Allows for reference to store data by creating simple, implicit getters
+    import { mapGetters } from "vuex";
+
     export default {
-
-        props: {
-
-            categories: { type: Array, required: true },
-            categoryClasses: { type: Object, required: true },
-            instructions: { type: String, required: true },
-            title: { type: String, required: true }
-        },
 
         data() {
 
             return {
 
-                selectedCategory: this.categories[0]
+                selectedCategory: ""
             };
         },
 
+        created() {
+
+            // Set the first given category as the selected one
+            this.selectedCategory = this.categories[0];
+        },
+
         computed: {
+
+            ...mapGetters([
+
+                "categories",
+                "categoryClasses"
+            ]),
 
             categoryTable() {
 

--- a/components/category-select-table.vue
+++ b/components/category-select-table.vue
@@ -16,9 +16,6 @@
                     selected-variant=""
                     :tbody-tr-class="styleTableRow"
                     thead-class="hidden" />
-                <b-icon-plus-circle
-                    style="display: block; margin-left: auto; margin-right: auto;"
-                    @click="addCustomCategory" />
             </b-col>
         </b-row>
 

--- a/components/category-select-table.vue
+++ b/components/category-select-table.vue
@@ -30,18 +30,9 @@
 
     export default {
 
-        data() {
+        props: {
 
-            return {
-
-                selectedCategory: ""
-            };
-        },
-
-        created() {
-
-            // Set the first given category as the selected one
-            this.selectedCategory = this.categories[0];
+            selectedCategory: { type: String, required: true }
         },
 
         computed: {
@@ -66,11 +57,8 @@
                 // If a new category was selected...
                 if ( 0 !== p_row.length ) {
 
-                    // 1. Save the newly selected category, if given
-                    this.selectedCategory = p_row[0].category;
-
-                    // 2. Tell the parent page about the category selction
-                    this.$emit("category-select", { category: this.selectedCategory });
+                    // Tell the parent page about the category selction
+                    this.$emit("category-select", { category: p_row[0].category });
                 }
             },
 

--- a/cypress/component/category-select-table.cy.js
+++ b/cypress/component/category-select-table.cy.js
@@ -3,88 +3,44 @@ import CategorySelectTable from "~/components/category-select-table.vue";
 // Documentation for testing Vue events of components
 // https://docs.cypress.io/guides/component-testing/events-vue
 
+// Mocks
+
 const state = {
-
-    categories: [
-
-        "Subject ID",
-        "Age",
-        "Sex",
-        "Diagnosis",
-        "Assessment Tool"
-    ],
-
-    categoryClasses: {},
-
-    categoryToColorMap: {},
-
-    toolColorPalette: {
-
-        color1: "category-style-0",
-        color2: "category-style-1",
-        color3: "category-style-2",
-        color4: "category-style-3",
-        color5: "category-style-4",
-        colorDefault: "category-style-default"
-    },
 
     getters: {
 
-        categories: () => state.categories,
-        categoryClasses: () => state.categoryClasses
+        categories: () => {
+
+            return [
+
+                "Subject ID",
+                "Age",
+                "Sex",
+                "Diagnosis",
+                "Assessment Tool"
+            ];
+        },
+
+        categoryClasses: () => {
+
+            return {
+
+                "Subject ID": "category-style-0",
+                "Age": "category-style-1",
+                "Sex": "category-style-2",
+                "Diagnosis": "category-style-3",
+                "Assessment Tool": "category-style-4"
+            };
+        }
     }
 };
 
-// const plugins = ["bootstrap-vue", "vue-select"];
-
-function setupCategoryClasses(p_store) {
-
-    // 1. Get color keys from tool color palette
-    const colorKeys = Object.keys(p_store.toolColorPalette);
-
-    // 2. Create the category to color map
-    let assignedCategories = 0;
-    for ( let index = 0; index < p_store.categories.length &&
-            index < colorKeys.length; index++ ) {
-
-        // A. Stop when the default color key has been reached
-        if ( "colorDefault" === colorKeys[index] )
-            break;
-
-        // B. Map this category to color key
-        p_store.categoryToColorMap[p_store.categories[index]] = colorKeys[index];
-
-        // C. Keep track of how many categories have been assigned color keys
-        assignedCategories += 1;
-    }
-    // D. Issue warning if there are not enough color keys for the given category set
-    if ( p_store.categories.length > assignedCategories ) {
-        console.log("WARNING: Not all categories have been assigned color keys!");
-    }
-
-    // 4. Set up the category to CSS class map
-
-    // A. Create a map between category names and color classes
-    const mapArray = [];
-    for ( let index = 0; index < p_store.categories.length; index++ ) {
-
-        const category = p_store.categories[index];
-        const colorID = p_store.categoryToColorMap[category];
-        const colorClass = p_store.toolColorPalette[colorID];
-
-        mapArray.push([category, colorClass]);
-    }
-
-    // B. Save the new category to class map
-    p_store.categoryClasses = Object.fromEntries(mapArray);
-}
+// Tests
 
 describe("Table for selecting categories to linking to table columns on the categorization page", () => {
 
-    // Setup category clases in the mock store
-    setupCategoryClasses(state);
-
     it("Select each category", () => {
+
         // 1. Arrange
 
         // Set up the spy, mount the component, and bind the spy to it
@@ -93,24 +49,22 @@ describe("Table for selecting categories to linking to table columns on the cate
 
             computed: state.getters,
 
-            listeners: {
-
-                "category-select": onCategorySelectSpy
-            },
+            listeners: { "category-select": onCategorySelectSpy },
 
             plugins: ["bootstrap-vue"]
         });
 
         // Test each row in the category select table
-        for ( let index = 0; index < state.categories.length; index++ ) {
+        for ( let index = 0; index < state.getters.categories().length; index++ ) {
 
             // 2. Act
-            cy.get(`.category-style-${index}`).click();
+            cy.get("td")
+                .contains(state.getters.categories()[index])
+                .click();
 
             // 3. Assert
-            cy.get("@onCategorySelectSpy").should(
-                "have.been.calledWith",
-                {category: state.categories[index]});
+            cy.get("@onCategorySelectSpy")
+                .should("have.been.calledWith", { category: state.getters.categories()[index] });
         }
     });
 });

--- a/cypress/component/category-select-table.cy.js
+++ b/cypress/component/category-select-table.cy.js
@@ -1,0 +1,116 @@
+import CategorySelectTable from "~/components/category-select-table.vue";
+
+// Documentation for testing Vue events of components
+// https://docs.cypress.io/guides/component-testing/events-vue
+
+const state = {
+
+    categories: [
+
+        "Subject ID",
+        "Age",
+        "Sex",
+        "Diagnosis",
+        "Assessment Tool"
+    ],
+
+    categoryClasses: {},
+
+    categoryToColorMap: {},
+
+    toolColorPalette: {
+
+        color1: "category-style-0",
+        color2: "category-style-1",
+        color3: "category-style-2",
+        color4: "category-style-3",
+        color5: "category-style-4",
+        colorDefault: "category-style-default"
+    },
+
+    getters: {
+
+        categories: () => state.categories,
+        categoryClasses: () => state.categoryClasses
+    }
+};
+
+// const plugins = ["bootstrap-vue", "vue-select"];
+
+function setupCategoryClasses(p_store) {
+
+    // 1. Get color keys from tool color palette
+    const colorKeys = Object.keys(p_store.toolColorPalette);
+
+    // 2. Create the category to color map
+    let assignedCategories = 0;
+    for ( let index = 0; index < p_store.categories.length &&
+            index < colorKeys.length; index++ ) {
+
+        // A. Stop when the default color key has been reached
+        if ( "colorDefault" === colorKeys[index] )
+            break;
+
+        // B. Map this category to color key
+        p_store.categoryToColorMap[p_store.categories[index]] = colorKeys[index];
+
+        // C. Keep track of how many categories have been assigned color keys
+        assignedCategories += 1;
+    }
+    // D. Issue warning if there are not enough color keys for the given category set
+    if ( p_store.categories.length > assignedCategories ) {
+        console.log("WARNING: Not all categories have been assigned color keys!");
+    }
+
+    // 4. Set up the category to CSS class map
+
+    // A. Create a map between category names and color classes
+    const mapArray = [];
+    for ( let index = 0; index < p_store.categories.length; index++ ) {
+
+        const category = p_store.categories[index];
+        const colorID = p_store.categoryToColorMap[category];
+        const colorClass = p_store.toolColorPalette[colorID];
+
+        mapArray.push([category, colorClass]);
+    }
+
+    // B. Save the new category to class map
+    p_store.categoryClasses = Object.fromEntries(mapArray);
+}
+
+describe("Table for selecting categories to linking to table columns on the categorization page", () => {
+
+    // Setup category clases in the mock store
+    setupCategoryClasses(state);
+
+    it("Select each category", () => {
+        // 1. Arrange
+
+        // Set up the spy, mount the component, and bind the spy to it
+        const onCategorySelectSpy = cy.spy().as("onCategorySelectSpy");
+        cy.mount(CategorySelectTable, {
+
+            computed: state.getters,
+
+            listeners: {
+
+                "category-select": onCategorySelectSpy
+            },
+
+            plugins: ["bootstrap-vue"]
+        });
+
+        // Test each row in the category select table
+        for ( let index = 0; index < state.categories.length; index++ ) {
+
+            // 2. Act
+            cy.get(`.category-style-${index}`).click();
+
+            // 3. Assert
+            cy.get("@onCategorySelectSpy").should(
+                "have.been.calledWith",
+                {category: state.categories[index]});
+        }
+    });
+});


### PR DESCRIPTION
Newly refactored category select table on the categorization page...

1. has required input (`categories`, `categoryClasses`) directly from the store 
2. former `instructions` and `title` props have also been removed, relegated to the new refactored categorization page that will act more like a layout.
3. `selectedCategory` is still emitted to the categorization page (which maintains a `currentCategory` field to share between the `category-select-table` and the `column-linking-table`)

The component test...

1. Mocks store required input via getters
2. Runs through selection of all the default categories.
3. Spies for the emitted selected category output