### PR TITLE
Next page accessibility/navbar/layout refactor + All page refactor

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5,6 +5,12 @@
 	display: none;
 }
 
+.instructions-text {
+
+	color: grey;
+	font-style: italic;
+}
+
 /* Bootstrap styles */
 
 .container-fluid {
@@ -17,14 +23,6 @@
 	margin: 1em;
 	padding-left: 2em;
 	padding-right: 2em;
-}
-
-/* Categorization page styles */
-
-.instructions-text {
-
-	color: grey;
-	font-style: italic;
 }
 
 /* Annotation page styles */

--- a/components/next-page.vue
+++ b/components/next-page.vue
@@ -1,0 +1,83 @@
+<template>
+
+    <!-- Next page button -->
+    <b-row align-h="end">
+        <b-col class="text-right" cols="4">
+
+            <!-- Optional instructions to remind user of criteria to proceed to the next page -->
+            <p class="instructions-text" v-if="!pageAccessible(currentPage)">
+                {{ uiText.instructions[currentPage] }}
+            </p>
+
+            <!-- Button to proceed to the next page -->
+            <!-- Only enabled when next page accessibility criteria have been met -->
+            <b-button
+                class="float-right"
+                data-cy="button-nextpage"
+                :disabled="!pageData[nextPage].accessible"
+                :to="'/' + pageData[nextPage].location"
+                :variant="nextPageButtonColor">
+                {{ uiText.button[currentPage] }}
+            </b-button>
+        </b-col>
+    </b-row>
+
+</template>
+
+<script>
+
+    // Allows for reference to store data by creating simple, implicit getters
+    import { mapGetters } from "vuex";
+
+    // Fields listed in mapState below can be found in the store (index.js)
+    import { mapState } from "vuex";
+
+    export default {
+
+        data() {
+
+            return {
+
+                uiText: {
+
+                    button: {
+
+                        "home": "Next step: Categorize columns",
+                        "categorization": "Next step: Annotate columns",
+                        "annotation": "Next step: Review and download harmonized data"
+                    },
+
+                    instructions: {
+
+                        "home": "",
+                        "categorization": "One column must be categorized as 'Subject ID' and all assessment tools must be grouped to proceed",
+                        "annotation": ""
+                    }
+                }
+            };
+        },
+
+        computed: {
+
+            ...mapGetters([
+
+                "nextPage",
+                "nextPageAccessible",
+                "pageAccessible"
+            ]),
+
+            ...mapState([
+
+                "currentPage",
+                "pageData"
+            ]),
+
+            nextPageButtonColor() {
+
+                // Bootstrap variant color of the button leading to the next page
+                return this.nextPageAccessible ? "success" : "secondary";
+            }
+        }
+    };
+
+</script>

--- a/components/next-page.vue
+++ b/components/next-page.vue
@@ -16,7 +16,8 @@
                 data-cy="button-nextpage"
                 :disabled="!pageData[nextPage].accessible"
                 :to="'/' + pageData[nextPage].location"
-                :variant="nextPageButtonColor">
+                :variant="nextPageButtonColor"
+                @click="setCurrentPage(nextPage)">
                 {{ uiText.button[currentPage] }}
             </b-button>
         </b-col>
@@ -28,6 +29,9 @@
 
     // Allows for reference to store data by creating simple, implicit getters
     import { mapGetters } from "vuex";
+
+    // Allows for direct mutations of store data
+    import { mapMutations } from "vuex";
 
     // Fields listed in mapState below can be found in the store (index.js)
     import { mapState } from "vuex";
@@ -77,6 +81,14 @@
                 // Bootstrap variant color of the button leading to the next page
                 return this.nextPageAccessible ? "success" : "secondary";
             }
+        },
+
+        methods: {
+
+            ...mapMutations([
+
+                "setCurrentPage"
+            ])
         }
     };
 

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -26,7 +26,8 @@
                         :data-cy="'menu-item-' + navItem.pageName"
                         :disabled="!pageAccessible(navItem.pageName)"
                         :key="navItem.pageName"
-                        :to="navItem.location">
+                        :to="navItem.location"
+                        @click="setCurrentPage(navItem.pageName)">
                         {{ navItem.fullName }}
                     </b-nav-item>
 
@@ -44,6 +45,9 @@
 
     // Allows for reference to store data by creating simple, implicit getters
     import { mapGetters } from "vuex";
+
+    // Allows for direct mutations of store data
+    import { mapMutations } from "vuex";
 
     // Fields listed in mapState below can be found in the store (index.js)
     import { mapState } from "vuex";
@@ -82,6 +86,11 @@
         },
 
         methods: {
+
+            ...mapMutations([
+
+                "setCurrentPage"
+            ]),
 
             getNavItemColor(p_navItemData) {
 

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -20,13 +20,13 @@
                 <b-navbar-nav class="ml-auto" id="right-nav">
 
                     <b-nav-item
-                        v-for="(navItem, _key) in navItems"
-                        :active="pageName === navItem.fullName"
+                        v-for="(navItem, _key) in pageData"
+                        :active="currentPageName === navItem.fullName"
+                        :class="getNavItemColor(navItem)"
                         :data-cy="'menu-item-' + navItem.pageName"
-                        :disabled="!navItem.accessible"
+                        :disabled="!pageAccessible(navItem.pageName)"
                         :key="navItem.pageName"
-                        :to="navItem.location"
-                        :class="determineNavItemColor(navItem)">
+                        :to="navItem.location">
                         {{ navItem.fullName }}
                     </b-nav-item>
 
@@ -42,13 +42,13 @@
 
 <script>
 
+    // Allows for reference to store data by creating simple, implicit getters
+    import { mapGetters } from "vuex";
+
+    // Fields listed in mapState below can be found in the store (index.js)
+    import { mapState } from "vuex";
+
     export default {
-
-        props: {
-
-            navItems: { type: Object, required: true },
-            pageName: { type: String, required: true }
-        },
 
         data() {
 
@@ -62,14 +62,34 @@
             };
         },
 
+        computed: {
+
+            ...mapGetters([
+
+                "pageAccessible"
+            ]),
+
+            ...mapState([
+
+                "currentPage",
+                "pageData"
+            ]),
+
+            currentPageName() {
+
+                return this.pageData[this.currentPage].fullName;
+            }
+        },
+
         methods: {
 
-            determineNavItemColor(p_navItemData) {
+            getNavItemColor(p_navItemData) {
 
+                // Default color for currently unaccessible page
                 let variant = "secondary";
 
-                // The nav item for this page
-                if ( this.pageName === p_navItemData.fullName ) {
+                // The nav item color for the current page
+                if ( this.currentPageName === p_navItemData.fullName ) {
                     variant = "dark";
                 }
                 // Else, if the page is accessible
@@ -81,6 +101,7 @@
             }
         }
     };
+
 </script>
 
 <style>
@@ -105,6 +126,7 @@
     }
 
     .navbar {
+
         background-color: white !important;
     }
 
@@ -124,6 +146,7 @@
     }
 
     #right-nav {
+
         padding-right: 2em;
     }
 

--- a/cypress/e2e/page/categorization-pagetests.cy.js
+++ b/cypress/e2e/page/categorization-pagetests.cy.js
@@ -31,14 +31,7 @@ describe("tests on categorization page ui via programmatic state loading and sto
                 // 2. Load test data
                 cy.loadTestDataIntoStore(p_dataset);
 
-                // 3. Enable access to the categorization page
-                cy.dispatchToNuxtStore("initializePage", {
-
-                    enable: true,
-                    pageName: "categorization"
-                });
-
-                // 4. Move to categorization page
+                // 3. Move to categorization page
                 // NOTE: Routing to the page prevents the Vuex store from being wiped
                 // when a page is 'visited' by Cypress
                 cy.window().its("$nuxt.$router").then(router => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -152,7 +152,7 @@ Cypress.Commands.add("loadAppState", (p_pageName, p_dataset, p_pageData) => {
             for ( let index = 0; index < columnCount; index++ ) {
 
                 // A. Link the column to this category
-                cy.dispatchToNuxtStore("linkColumnWithCategory", {
+                cy.dispatchToNuxtStore("alterColumnCategoryRelation", {
 
                     category: category,
                     column: p_dataset["category_columns"][category][index]
@@ -187,14 +187,6 @@ Cypress.Commands.add("loadAppState", (p_pageName, p_dataset, p_pageData) => {
                 });
             }
         }
-
-        // 3. Call page initialization store function for the annotation page
-        cy.dispatchToNuxtStore("initializePage", {
-
-            pageName: "annotation",
-            enable: true
-        });
-
     } else if ( "download" == p_pageName ) {
 
         // Load state for download page

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -56,7 +56,7 @@ Cypress.Commands.add("assertNextPageAccess", (p_pageName, p_enabled, p_checkMenu
         .should(chainer, "disabled");
 });
 
-Cypress.Commands.add("categorizeColumn", (p_category, p_columnName) => {
+Cypress.Commands.add("categorizeColumn", (p_category, p_column) => {
 
     // 1. Select the given category in the categorization table
     cy.get("[data-cy='categorization-table']")
@@ -65,7 +65,7 @@ Cypress.Commands.add("categorizeColumn", (p_category, p_columnName) => {
 
     // 2. Link the category to this column in the column linking table
     cy.get("[data-cy='column-linking-table'] tbody > tr > td")
-        .contains(p_columnName)
+        .contains(p_column)
         .click();
 });
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,13 +3,13 @@
     <div>
 
         <!-- Navigation bar -->
-        <tool-navbar
-            :nav-items="pageData"
-            :nav-order="pageOrder"
-            :page-name="pageData[currentPage].fullName" />
+        <tool-navbar />
 
         <!-- Current page -->
         <Nuxt />
+
+        <!-- Next page button -->
+        <next-page />
 
     </div>
 
@@ -17,23 +17,9 @@
 
 <script>
 
-    // Allows for reference to store data by creating simple, implicit getters
-    // Fields listed in mapState below can be found in the store (index.js)
-    import { mapState } from "vuex";
-
     export default {
 
-        name: "DefaultLayout",
-
-        computed: {
-
-            ...mapState([
-
-                "currentPage",
-                "pageData",
-                "pageOrder"
-            ])
-        }
+        name: "DefaultLayout"
     };
 
 </script>

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -96,12 +96,6 @@
             ])
         },
 
-        mounted() {
-
-            // Set the current page name
-            this.setCurrentPage("annotation");
-        },
-
         methods: {
 
             ...mapActions([
@@ -114,7 +108,6 @@
                 "deleteToolFromGroup",
                 "removeColumnCategorization",
                 "setAnnotatedDataTable",
-                "setCurrentPage",
                 "setMissingColumnValues"
             ]),
 

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -20,10 +20,10 @@
         <client-only>
             <!-- This gives us built-in keyboard navigation! -->
             <b-tabs
-                data-cy="annotation-category-tabs"
                 card
                 pills
                 vertical
+                data-cy="annotation-category-tabs"
                 nav-wrapper-class="col-2"
                 v-model="tabNavTitle">
 
@@ -39,8 +39,8 @@
                             :title="tabTitle(details)"
                             @remove:column="unlinkColumnFromCategory($event)"
                             @remove:missingValue="removeMissingValue($event)"
-                            @update:dataTable="saveAnnotatedDataTable($event)"
-                            @update:missingColumnValues="saveMissingColumnValues($event)"
+                            @update:dataTable="setAnnotatedDataTable($event.transformedTable)"
+                            @update:missingColumnValues="setMissingColumnValues($event)"
                             @update:missingValue="addMissingValue($event)" />
                     </b-card-text>
 
@@ -49,36 +49,23 @@
             </b-tabs>
         </client-only>
 
-        <b-row>
-
-            <b-col cols="7" />
-
-            <!-- Button to proceed to the next page -->
-            <!-- Only enabled when at least one annotation table write has been done -->
-            <b-col cols="5">
-                <b-button
-                    data-cy="button-nextpage"
-                    class="float-right"
-                    :disabled="!pageData.download.accessible"
-                    :to="'/' + pageData.download.location"
-                    :variant="nextPageButtonColor">
-                    {{ uiText.nextButton }}
-                </b-button>
-            </b-col>
-
-        </b-row>
-
     </b-container>
 
 </template>
 
 <script>
 
-    // Fields listed in mapState below can be found in the store (index.js)
-    import { mapState } from "vuex";
+    // Allows for reference to store actions (index.js)
+    import { mapActions } from "vuex";
 
     // Allows for reference to store data by creating simple, implicit getters
     import { mapGetters } from "vuex";
+
+    // Allows for direct mutations of store data
+    import { mapMutations } from "vuex";
+
+    // Fields listed in mapState below can be found in the store (index.js)
+    import { mapState } from "vuex";
 
     export default {
 
@@ -88,13 +75,7 @@
 
             return {
 
-                tabNavTitle: 0,
-
-                // Text for UI elements
-                uiText: {
-
-                    nextButton: "Next step: Review and download harmonized data"
-                }
+                tabNavTitle: 0
             };
         },
 
@@ -102,67 +83,40 @@
 
             ...mapGetters([
 
-                "columnDescription",
                 "getGroupOfTool",
-                "isDataAnnotated",
-                "isMissingValue",
-                "isToolGrouped",
-                "valueDescription"
+                "isToolGrouped"
             ]),
 
             ...mapState([
 
                 "annotationDetails",
                 "categoryClasses",
-                "columnToCategoryMap",
-                "dataDictionary",
-                "dataTable",
-                "pageData",
                 "missingColumnValues",
-                "missingValueLabel",
                 "toolGroups"
-            ]),
-
-            nextPageButtonColor() {
-
-                // Bootstrap variant color of the button leading to the download page
-                return this.pageData.download.accessible ? "success" : "secondary";
-            }
-        },
-
-        provide() {
-
-            return {
-
-                // Getters
-                columnDescription: this.columnDescription,
-                isMissingValue: this.isMissingValue,
-                valueDescription: this.valueDescription,
-
-                // Store fields
-                columnToCategoryMap: this.columnToCategoryMap,
-                dataDictionary: this.dataDictionary,
-                dataTable: this.dataTable,
-                missingColumnValues: this.missingColumnValues,
-                missingValueLabel: this.missingValueLabel,
-                toolGroups: this.toolGroups
-            };
+            ])
         },
 
         mounted() {
 
-            // 1. Set the current page name
-            this.$store.dispatch("setCurrentPage", "annotation");
-
-            // 2. If any data has been annotated, enable the download page and perform setup actions
-            this.$store.dispatch("initializePage", {
-
-                pageName: "download",
-                enable: this.isDataAnnotated
-            });
+            // Set the current page name
+            this.setCurrentPage("annotation");
         },
 
         methods: {
+
+            ...mapActions([
+
+                "revertColumnToOriginal"
+            ]),
+
+            ...mapMutations([
+
+                "deleteToolFromGroup",
+                "removeColumnCategorization",
+                "setAnnotatedDataTable",
+                "setCurrentPage",
+                "setMissingColumnValues"
+            ]),
 
             addMissingValue(p_event) {
 
@@ -199,7 +153,7 @@
                     columnMissingValues[p_event.column] = [p_event.value];
                 }
 
-                this.$store.dispatch("saveMissingColumnValues", columnMissingValues);
+                this.setMissingColumnValues(columnMissingValues);
             },
 
             removeMissingValue(p_event) {
@@ -217,28 +171,7 @@
                 }
 
                 // 2. Save the new missing value list for this column to the store
-                this.$store.dispatch("saveMissingColumnValues", missingValuesList);
-            },
-
-            saveAnnotatedDataTable(p_event) {
-
-                // 1. Save the annotated table in the store
-                this.$store.dispatch("saveAnnotatedDataTable", p_event.transformedTable);
-
-                // 2. Enable or disable the download page when the annotated data table has been written,
-                // depending on whether or not an annotation has occurred
-                this.$store.dispatch("initializePage", {
-
-                    pageName: "download",
-                    enable: this.isDataAnnotated
-                });
-            },
-
-            saveMissingColumnValues(p_event) {
-
-                // TODO: Document what this thing does and expects
-                // Save the algorithm and/or user-specified missing values to the store
-                this.$store.dispatch("saveMissingColumnValues", p_event);
+                this.setMissingColumnValues(missingValuesList);
             },
 
             tabStyle(p_details) {
@@ -267,17 +200,18 @@
             unlinkColumnFromCategory(p_event) {
 
                 // 1. Undo annotation for this column
-                this.$store.dispatch("revertColumnToOriginal", p_event.removedColumn);
+                this.revertColumnToOriginal(p_event.removedColumn);
 
                 // 2. Unlink this column from its currently-assigned category
-                this.$store.dispatch("unlinkColumnFromCategory", { column: p_event.removedColumn });
+                this.removeColumnCategorization(p_event.removedColumn);
 
                 // 3. If this column was a grouped tool, remove it from its group
                 if ( this.isToolGrouped(p_event.removedColumn) ) {
 
                     // A. Remove the tool from its group
                     const groupName = this.getGroupOfTool(p_event.removedColumn);
-                    this.$store.dispatch("removeToolFromGroup", {
+                    this.deleteToolFromGroup({
+
                         group: groupName,
                         tool: p_event.removedColumn
                     });
@@ -286,7 +220,7 @@
                     for ( const groupName in this.toolGroups ) {
                         if ( 0 === this.toolGroups[groupName].length ) {
 
-                            this.$store.dispatch("removeToolGroup", { name: groupName });
+                            this.deleteToolFromGroup({ name: groupName });
                         }
                     }
                 }

--- a/pages/categorization.vue
+++ b/pages/categorization.vue
@@ -41,9 +41,6 @@
 
 <script>
 
-    // Allows for direct mutations of store data
-    import { mapMutations } from "vuex";
-
     // Fields listed in mapState below can be found in the store (index.js)
     import { mapState } from "vuex";
 
@@ -77,19 +74,11 @@
 
         mounted() {
 
-            // 1. Set the current page name
-            this.setCurrentPage("categorization");
-
-            // 2. Set selected category to the first category by default
+            // Set selected category to the first category by default
             this.setSelectedCategory(this.categories[0]);
         },
 
         methods: {
-
-            ...mapMutations([
-
-                "setCurrentPage"
-            ]),
 
             setSelectedCategory(p_category) {
 

--- a/pages/categorization.vue
+++ b/pages/categorization.vue
@@ -7,58 +7,32 @@
 
             <!-- Category selection table -->
             <b-col cols="4">
+
+                <!-- Heading for category select component -->
+                <b-row>
+                    <h3>{{ uiText.categorySelectTitle }}</h3>
+                </b-row>
+
+                <!-- Instructions prompting the user how to link categories and columns -->
+                <b-row>
+                    <p class="instructions-text">
+                        {{ uiText.categorySelectInstructions }}
+                    </p>
+                </b-row>
+
                 <category-select-table
                     data-cy="categorization-table"
-                    :categories="categories"
-                    :category-classes="categoryClasses"
-                    :instructions="uiText.categorySelectInstructions"
-                    :title="uiText.categorySelectTitle"
-                    @category-select="setSelectedCategory($event)" />
+                    :selected-category="selectedCategory"
+                    @category-select="setSelectedCategory($event.category)" />
             </b-col>
 
             <!-- Category to column linking table -->
             <b-col cols="8">
                 <column-linking-table
                     data-cy="column-linking-table"
-                    :category-classes="categoryClasses"
-                    :column-to-category-map="columnToCategoryMap"
-                    :fields="columnLinkingTable.fields"
-                    :selected-category="selectedCategory"
-                    :table-data="columnToCategoryTable"
-                    @column-name-selected="tableClick($event)" />
+                    :selected-category="selectedCategory" />
             </b-col>
 
-        </b-row>
-
-        <!-- Whitespace to separate category-column categorization area from tool grouping area -->
-        <b-row>&nbsp;</b-row>
-
-        <!-- Tool grouping -->
-        <categ-tool-group
-            :column-names="dataTable.columns"
-            @remove-tool-from-group="removeToolFromGroup($event)"
-            @tool-group-action="toolGroupAction($event)" />
-
-        <!-- Next page button (passed inside categ-tool-group for UI space consideration) -->
-        <b-row>
-            <b-col class="text-right" cols="12">
-
-                <!-- Optional instructions to remind user of criteria to proceed to annotation page -->
-                <p class="instructions-text" v-if="!pageData.annotation.accessible">
-                    {{ uiText.nextPageCriteria }}
-                </p>
-
-                <!-- Button to proceed to the next page -->
-                <!-- Only enabled when at least one column has been categorized -->
-                <b-button
-                    class="float-right"
-                    data-cy="button-nextpage"
-                    :disabled="!pageData.annotation.accessible"
-                    :to="'/' + pageData.annotation.location"
-                    :variant="nextPageButtonColor">
-                    {{ uiText.nextButton }}
-                </b-button>
-            </b-col>
         </b-row>
 
     </b-container>
@@ -67,7 +41,9 @@
 
 <script>
 
-    // Allows for reference to store data by creating simple, implicit getters
+    // Allows for direct mutations of store data
+    import { mapMutations } from "vuex";
+
     // Fields listed in mapState below can be found in the store (index.js)
     import { mapState } from "vuex";
 
@@ -79,18 +55,6 @@
 
             return {
 
-                // Columns for file data table
-                columnLinkingTable: {
-
-                    fields: [
-
-                        { key: "column" },
-                        { key: "description" }
-                    ]
-                },
-
-                columnToCategoryTable: [],
-
                 // Category selection (default is index 0, no selection is -1)
                 selectedCategory: "",
 
@@ -98,9 +62,7 @@
                 uiText: {
 
                     categorySelectInstructions: "Click category and then corresponding column from tsv file",
-                    categorySelectTitle: "Recommended Categories",
-                    nextButton: "Next step: Annotate columns",
-                    nextPageCriteria: "One column must be categorized as 'Subject ID' and all assessment tools must be grouped to proceed"
+                    categorySelectTitle: "Recommended Categories"
                 }
             };
         },
@@ -109,241 +71,30 @@
 
             ...mapState([
 
-                "categories",
-                "categoryClasses",
-                "columnToCategoryMap",
-                "dataTable",
-                "dataDictionary",
-                "pageData",
-                "toolGroups"
-            ]),
-
-            nextPageButtonColor() {
-
-                // Bootstrap variant color of the button leading to the annotation page
-                return this.pageData.annotation.accessible ? "success" : "secondary";
-            }
-        },
-
-        provide() {
-
-            return {
-
-                "columnToCategoryMap": this.columnToCategoryMap,
-                "toolGroups": this.toolGroups
-            };
+                "categories"
+            ])
         },
 
         mounted() {
 
             // 1. Set the current page name
-            this.$store.dispatch("setCurrentPage", "categorization");
+            this.setCurrentPage("categorization");
 
-            // 2. Create the data structure for the category to column linking table
-            this.setupColumnToCategoryTable();
-
-            // 3. Set selected category to the first category by default
-            this.setSelectedCategory({ category: this.categories[0]});
-
-            // 4. Determine if the annotation page is available yet and if so, enable it and perform setup actions
-            this.$store.dispatch("initializePage", {
-
-                pageName: "annotation",
-                enable: this.nextPageAccessible()
-            });
+            // 2. Set selected category to the first category by default
+            this.setSelectedCategory(this.categories[0]);
         },
 
         methods: {
 
-            countLinkedColumns() {
+            ...mapMutations([
 
-                // Count the number of columns that have had categories linked to them
-                let links = 0;
-                for ( const column in this.columnToCategoryMap ) {
-                    if ( null !== this.columnToCategoryMap[column] )
-                        links += 1;
-                }
+                "setCurrentPage"
+            ]),
 
-                return links;
-            },
-
-            nextPageAccessible() {
-
-                // 1. Determine if at least one column has been linked to a category
-                const categorizationStatus = this.countLinkedColumns() > 0;
-
-                // 2. Determine if all columns assigned the 'Assessment Tool' category have been grouped
-                const assessmentToolColumns = [];
-                for ( const column in this.columnToCategoryMap ) {
-                    if ( "Assessment Tool" === this.columnToCategoryMap[column] ) {
-                        assessmentToolColumns.push(column);
-                    }
-                }
-
-                // 3. Make sure all assessment tool columns are grouped
-                for ( const toolGroup in this.toolGroups ) {
-                    for ( const tool of this.toolGroups[toolGroup] ) {
-                        const columnIndex = assessmentToolColumns.indexOf(tool);
-                        assessmentToolColumns.splice(columnIndex, 1);
-                    }
-                }
-                const toolGroupingStatus = ( 0 === assessmentToolColumns.length );
-
-                // 4. Make sure one (and only one) column has been categorized as 'Subject ID'
-                let subjectIDFound = 0;
-                for ( const column in this.columnToCategoryMap ) {
-                    if ( "Subject ID" === this.columnToCategoryMap[column] ) {
-                        subjectIDFound += 1;
-                    }
-                }
-                const singleSubjectIDColumn = ( 1 === subjectIDFound );
-
-                // Annotation page is only accessible if at least one column has
-                // been categorized and all assessment tools have been grouped
-                // and if one (and only one) column has been categorized as 'Subject ID'
-                return categorizationStatus && toolGroupingStatus && singleSubjectIDColumn;
-            },
-
-            removeToolFromGroup(p_toolData) {
-
-                this.$store.dispatch("removeToolFromGroup", p_toolData);
-            },
-
-            removeToolGroup(p_toolGroupData) {
-
-                // 1. Remove this tool group from the store
-                this.$store.dispatch("removeToolGroup", p_toolGroupData);
-
-                // 2. Enable the annotation page and perform setup actions if
-                // accessibility criteria have been met
-                this.$store.dispatch("initializePage", {
-
-                    pageName: "annotation",
-                    enable: this.nextPageAccessible()
-                });
-            },
-
-            saveNewToolGroup(p_toolGroupData) {
-
-                // 1. Create this new tool group in the store
-                this.$store.dispatch("createToolGroup", p_toolGroupData);
-
-                // 2. Enable the annotation page and perform setup actions if
-                // accessibility criteria have been met
-                this.$store.dispatch("initializePage", {
-
-                    pageName: "annotation",
-                    enable: this.nextPageAccessible()
-                });
-            },
-
-            setSelectedCategory(p_clickData) {
+            setSelectedCategory(p_category) {
 
                 // Save the name of the selected category
-                this.selectedCategory = p_clickData.category;
-            },
-
-            setupColumnToCategoryTable() {
-
-                // 0. Check that there is at least a data table and data dictionary in the data store
-                if ( null === this.dataTable.original )
-                    return;
-
-                // 1. Produce an array of dicts
-                this.columnToCategoryTable = [];
-
-                // A. Each dict has a header entry from the data table file
-                const headerFields = [];
-                for ( const headerField in this.dataTable.original[0] ) {
-
-                    // I. Save the header field in a list
-                    headerFields.push(headerField);
-
-                    // II. Save a new dict for this column and description
-                    this.columnToCategoryTable.push({
-
-                        "category": null,
-                        "column": headerField,
-                        "description": ""
-                    });
-                }
-
-                // 2. Add in descriptions if a data dictionary has been supplied
-                if ( null !== this.dataDictionary.original ) {
-
-                    // A. and a corresponding "description" column that is (possibly) sourced from the json file
-                    for ( const column in this.dataDictionary.original ) {
-
-                        // I. Save a lowercase version of the current json key
-                        const columnLowercase = column.toLowerCase();
-
-                        // II. Try to match the json key with one in the tsv file
-                        if ( headerFields.includes(columnLowercase) ) {
-
-                            for ( let index = 0; index < this.columnToCategoryTable.length; index++ ) {
-
-                                // NOTE: Advanced column name matching here between tsv and json? J. Armoza 01/26/22
-                                if ( columnLowercase === this.columnToCategoryTable[index].column.toLowerCase() ) {
-
-                                    // a. Determine the description string for this json file column entry
-                                    let descriptionStr = "";
-                                    for ( const subkey in this.dataDictionary.original[column] ) {
-
-                                        if ( "description" === subkey.toLowerCase() ) {
-                                            descriptionStr = this.dataDictionary.original[column][subkey];
-                                            break;
-                                        }
-                                    }
-
-                                    // b. Save the description from the json file colum entry
-                                    this.columnToCategoryTable[index].description = descriptionStr;
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-
-            tableClick(p_clickData) {
-
-                // 1. Style or unstyle table row
-
-                // A. Determine if category-column linking or unlinking has occurred
-                const linking = ( this.selectedCategory !== this.columnToCategoryMap[p_clickData.column] );
-
-                // B. Record the linking/unlinking in the data store
-                const dataStoreFunction = ( linking ) ? "linkColumnWithCategory" : "unlinkColumnFromCategory";
-
-                // I. Build a new object for passing to the store for category-column linking
-                const dataForStore = { column: p_clickData["column"] };
-                if ( linking ) {
-                    dataForStore.category = this.selectedCategory;
-                }
-
-                // II. Link or unlink the currently-selected category and the clicked column
-                this.$store.dispatch(dataStoreFunction, dataForStore);
-
-                // 2. Enable the annotation page and perform setup actions if
-                // accessibility criteria have been met
-                this.$store.dispatch("initializePage", {
-
-                    pageName: "annotation",
-                    enable: this.nextPageAccessible()
-                });
-            },
-
-            toolGroupAction(p_event) {
-
-                // 1. Create, modify, or remove this tool group in the store
-                this.$store.dispatch(p_event.action, p_event.data);
-
-                // 2. Enable the annotation page and perform setup actions if
-                // accessibility criteria have been met
-                this.$store.dispatch("initializePage", {
-
-                    pageName: "annotation",
-                    enable: this.nextPageAccessible()
-                });
+                this.selectedCategory = p_category;
             }
         }
     };

--- a/pages/download.vue
+++ b/pages/download.vue
@@ -203,11 +203,12 @@
                 for ( const groupName in this.toolGroups ) {
 
                     // NOTE: Availability suffix string should be in store?
-                    const columnName = groupName + "_avail";
+                    const column = groupName + "_avail";
 
                     // Only include tool group names that are available for this subject
-                    if ( true === p_row[columnName] ) {
-                        subjectJSON["assessment_tool"].push(columnName);
+                    if ( true === p_row[column] ) {
+
+                        subjectJSON["assessment_tool"].push(column);
                     }
                 }
 

--- a/pages/download.vue
+++ b/pages/download.vue
@@ -75,12 +75,6 @@
             };
         },
 
-        mounted() {
-
-            // Create a reverse of the column to category map in the store
-            this.refreshCategoryToColumnMap();
-        },
-
         computed: {
 
             ...mapGetters([

--- a/pages/download.vue
+++ b/pages/download.vue
@@ -44,9 +44,6 @@
     // Allows for reference to store data by creating simple, implicit getters
     import { mapGetters } from "vuex";
 
-    // Allows for direct mutations of store data
-    import { mapMutations } from "vuex";
-
     // Fields listed in mapState below can be found in the store (index.js)
     import { mapState } from "vuex";
 
@@ -80,10 +77,7 @@
 
         mounted() {
 
-            // 1. Set the current page
-            this.setCurrentPage("download");
-
-            // 2. Create a reverse of the column to category map in the store
+            // Create a reverse of the column to category map in the store
             this.refreshCategoryToColumnMap();
         },
 
@@ -141,11 +135,6 @@
         },
 
         methods: {
-
-            ...mapMutations([
-
-                "setCurrentPage"
-            ]),
 
             downloadAnnotatedData() {
 

--- a/pages/download.vue
+++ b/pages/download.vue
@@ -24,8 +24,8 @@
             <!-- Only enabled when annotation has been at least partially completed -->
             <b-col cols="3">
                 <b-button
-                    data-cy="download-button"
                     class="float-right"
+                    data-cy="download-button"
                     :disabled="!isDataAnnotated"
                     :variant="downloadButtonColor"
                     @click="downloadAnnotatedData">
@@ -42,8 +42,13 @@
 <script>
 
     // Allows for reference to store data by creating simple, implicit getters
-    import { mapState } from "vuex";
     import { mapGetters } from "vuex";
+
+    // Allows for direct mutations of store data
+    import { mapMutations } from "vuex";
+
+    // Fields listed in mapState below can be found in the store (index.js)
+    import { mapState } from "vuex";
 
     // Saves file to user's computer
     import { saveAs } from "file-saver";
@@ -56,15 +61,13 @@
 
             return {
 
-                categoryToColumnMap: {},
-
                 jsonSpacing: 4,
 
                 // Size of the file display textboxes
                 textArea: {
 
-                    width: 5,
-                    height: 800
+                    height: 800,
+                    width: 5
                 },
 
                 // Text for UI elements
@@ -73,6 +76,15 @@
                     downloadButton: "Download Annotated Data"
                 }
             };
+        },
+
+        mounted() {
+
+            // 1. Set the current page
+            this.setCurrentPage("download");
+
+            // 2. Create a reverse of the column to category map in the store
+            this.refreshCategoryToColumnMap();
         },
 
         computed: {
@@ -89,6 +101,26 @@
                 "missingValueLabel",
                 "toolGroups"
             ]),
+
+            categoryToColumnMap() {
+
+                // Create a reverse lookup map of the columnToCategory map in the store
+                const categoryToColumnMap = {};
+                for ( const column in this.columnToCategoryMap ) {
+
+                    const category = this.columnToCategoryMap[column];
+
+                    // Categories may have multiple columns associated with them
+                    if ( !Object.keys(categoryToColumnMap).includes(category) ) {
+
+                        categoryToColumnMap[category] = [];
+                    }
+
+                    categoryToColumnMap[category].push(column);
+                }
+
+                return categoryToColumnMap;
+            },
 
             datasetName() {
 
@@ -108,16 +140,12 @@
             }
         },
 
-        mounted() {
-
-            // 1. Set the current page
-            this.$store.dispatch("setCurrentPage", "download");
-
-            // 2. Create a reverse of the column to category map in the store
-            this.refreshCategoryToColumnMap();
-        },
-
         methods: {
+
+            ...mapMutations([
+
+                "setCurrentPage"
+            ]),
 
             downloadAnnotatedData() {
 
@@ -133,32 +161,6 @@
 
                 const blob = new Blob([JSON.stringify(p_jsonData, null, this.jsonSpacing)], {type: "text/plain;charset=utf-8"});
                 saveAs(blob, this.defaultOutputFilename);
-            },
-
-            refreshCategoryToColumnMap() {
-
-                this.categoryToColumnMap = {};
-                for ( const column in this.columnToCategoryMap ) {
-
-                    const myCategory = this.columnToCategoryMap[column];
-
-                    // Categories may have multiple columns associated with them
-                    if ( !Object.keys(this.categoryToColumnMap).includes(myCategory) ) {
-                        this.categoryToColumnMap[myCategory] = [];
-                    }
-                    this.categoryToColumnMap[myCategory].push(column);
-                }
-            },
-
-            transformAnnotatedTableToJSON() {
-
-                // Transform the annotated data table into a new subject-centric JSON format for the output file
-                return {
-
-                    name: this.datasetName,
-                    type: "dataset",
-                    hasSamples: this.dataTable.annotated.map(row => this.transformAnnotatedRowToSubjectJSON(row))
-                };
             },
 
             transformAnnotatedRowToSubjectJSON(p_row) {
@@ -177,11 +179,13 @@
 
                 // B. Age
                 if ( availableCategories.includes("Age") ) {
+
                     subjectJSON["age"] = p_row[this.categoryToColumnMap["Age"][0]];
                 }
 
                 // C. Sex
                 if ( availableCategories.includes("Sex") ) {
+
                     subjectJSON["sex"] = p_row[this.categoryToColumnMap["Sex"][0]];
                 }
 
@@ -189,9 +193,8 @@
                 if ( availableCategories.includes("Diagnosis") ) {
 
                     // I. Create a list of values from the diagnosis columns in the annotated table row
-                    subjectJSON["diagnosis"] = this.categoryToColumnMap["Diagnosis"].map(column => {
-                        return {identifier: p_row[column]};
-                    })
+                    subjectJSON["diagnosis"] = this.categoryToColumnMap["Diagnosis"]
+                        .map(column => { return {identifier: p_row[column]}; })
                         .filter(value => this.missingValueLabel !== value.identifier);
                 }
 
@@ -199,7 +202,7 @@
                 subjectJSON["assessment_tool"] = [];
                 for ( const groupName in this.toolGroups ) {
 
-                    // Availability suffix string should be in store?
+                    // NOTE: Availability suffix string should be in store?
                     const columnName = groupName + "_avail";
 
                     // Only include tool group names that are available for this subject
@@ -209,6 +212,17 @@
                 }
 
                 return subjectJSON;
+            },
+
+            transformAnnotatedTableToJSON() {
+
+                // Transform the annotated data table into a new subject-centric JSON format for the output file
+                return {
+
+                    name: this.datasetName,
+                    type: "dataset",
+                    hasSamples: this.dataTable.annotated.map(row => this.transformAnnotatedRowToSubjectJSON(row))
+                };
             }
         }
     };

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -134,12 +134,6 @@
             }
         },
 
-        mounted() {
-
-            // Set the current page name
-            this.setCurrentPage("home");
-        },
-
         methods: {
 
             ...mapActions([
@@ -150,8 +144,7 @@
 
             ...mapMutations([
 
-                "createColumnToCategoryMap",
-                "setCurrentPage"
+                "createColumnToCategoryMap"
             ]),
 
             saveDataDictionary(p_fileData) {

--- a/store/index.js
+++ b/store/index.js
@@ -217,6 +217,9 @@ export const actions = {
 
         // 2. Setup annotation-related data structures based on the given categories\
         commit("setupAnnotationDetails", annotationDetails);
+
+        // 3. Set the current page as the landing page
+        commit("setCurrentPage", "home");
     },
 
     // Tool navigation


### PR DESCRIPTION
This PR represents changes that we have planned for I/O refactor for the annotation tool's pages but also our refactor next page accessibility/the navbar and default layout.

Since most of these changes are interlinked, it made sense to include them in one PR. This is also a "in the dark" PR given that we have no good means of testing the following changes throughout the app because of the ongoing refactor. This ties together issues #232, #218, #214, #215, #216, and #217.

So the code review for this will be more of a visual inspection of the changes made. (I will leave it as a draft for now as @surchs may continue this work next week while I am away.)

Below is a summary of the changes made thus far.

**Next page and Layout**

This is a new component that sits on the bottom right of the layout. It is chiefly a next page button whose state is reactive to that of the app's (see new function `nextPageAccessible` in the store).

The layout has been slimmed down considerably as well given our I/O refactor specifications.

**Tool navbar**

I/O refactor changes have been made in addition to incorporation of new page accessibility/store functionality.

**Store**

1. Wrapper actions have been removed in favor of direct calls to mutations
2. Getters are now solely for complex gets of store data. If a page or component needs read access to a store field, it uses the `mapState` syntax.
3. Page accessibility is now handled in a reactive manner via `pageAccessibility` and `nextPageAccessibility`. 
4. Some general spacing/naming cleanup
5. Actions are for more complex mutations of the store, and/or when store logic is required before doing so.

**All pages**

1. I/O refactor has been incorporated throughout. This includes the removal of most of prop passing and provide/injects. See store summary above for specifics about component/page use of the `map*` syntax.
2. Since the only page "initialization" that was happening was related to the creation of the `columnToCategoryMap`, this has been moved to the index page and there is no longer any `initializePage` calls. Each page's `mounted` call just sets the `currentPage`. As such, all tool navigation is chiefly reactive via `pageAccessibility` (in the tool bar and next page button components).
3. Removal/adjustment of functions

**e2e test files**

Adjustments for above store/refactor changes have been made.