### PR TITLE
Refactor annotation-tab component 

### DIFF
--- a/components/annot-tab.vue
+++ b/components/annot-tab.vue
@@ -1,21 +1,21 @@
 <template>
 
-    <div>
+    <div :data-cy="activeCategory">
 
         <!-- Explanation text for this annotation tab -->
-        <annot-explanation :data-cy="'annot-expl-' + title" />
+        <annot-explanation :data-cy="('annot-expl-' + activeCategory)" />
 
         <!-- Lists all the columns linked to the category of this annotation tab -->
-        <annot-columns
-            :active-category="`age`" />
+        <annot-columns :data-cy="('annot-col-' + activeCategory)" :active-category="activeCategory" />
 
         <!-- Lists any values determined to be missing (e.g. potentially invalid) in this tab's columns -->
-        <annot-missing-values />
+        <annot-missing-values :data-cy="('annot-missing-' + activeCategory)" :active-category="activeCategory" />
 
         <!-- Component specializing in the particular kind of annotation for this tab's category -->
         <component
-            :is="annot-explanation"
-            :data-cy="'annot-component-' + title"
+            :is="getAnnotationComponent(activeCategory)"
+            :data-cy="(getAnnotationComponent(activeCategory) + '-' + activeCategory)"
+            :active-category="activeCategory"
             :id-field="idField"
             :title="title" />
 
@@ -30,25 +30,22 @@
 
     export default {
 
+        props: {
+            activeCategory: { type: String, required: true }
+        },
+
         data() {
 
             return {
 
-                details: "",
-                title: "hello",
-
-                // Category of the current annotation tab
-                category: "",
-
-                // String name of the column assigned the 'Subject ID' category in the data table
-                idField: "",
-
-                // Disabled state of the save annotation button
-                saveButtonDisabled: true
+                title: "hello"
             };
         },
 
         computed: {
+            ...mapGetters([
+                "getAnnotationComponent"
+            ])
         }
 
     };

--- a/components/annot-tab.vue
+++ b/components/annot-tab.vue
@@ -17,7 +17,7 @@
             :data-cy="(getAnnotationComponent(activeCategory) + '-' + activeCategory)"
             :active-category="activeCategory"
             :id-field="idField"
-            :title="title" />
+            :title="('annotate_' + activeCategory)" />
 
     </div>
 
@@ -32,14 +32,6 @@
 
         props: {
             activeCategory: { type: String, required: true }
-        },
-
-        data() {
-
-            return {
-
-                title: "hello"
-            };
         },
 
         computed: {

--- a/components/annot-tab.vue
+++ b/components/annot-tab.vue
@@ -3,34 +3,21 @@
     <div>
 
         <!-- Explanation text for this annotation tab -->
-        <annot-explanation :explanation="details.explanation" :index="details.id" :data-cy="'annot-expl-' + title" />
+        <annot-explanation :data-cy="'annot-expl-' + title" />
 
         <!-- Lists all the columns linked to the category of this annotation tab -->
         <annot-columns
-            :active-category="details.category"
-            :relevant-columns="relevantColumns"
-            @remove:column="$emit('remove:column', $event)" />
+            :active-category="`age`" />
 
         <!-- Lists any values determined to be missing (e.g. potentially invalid) in this tab's columns -->
-        <annot-missing-values
-            :relevant-columns="relevantColumns"
-            @remove:missingValue="$emit('remove:missingValue', $event)"
-            @update:missingColumnValues="$emit('update:missingColumnValues', $event)" />
+        <annot-missing-values />
 
         <!-- Component specializing in the particular kind of annotation for this tab's category -->
         <component
-            :is="details.specializedComponent"
+            :is="annot-explanation"
             :data-cy="'annot-component-' + title"
             :id-field="idField"
-            :details="details"
-            :options="details.options"
-            :relevant-columns="relevantColumns"
-            :title="title"
-            :unique-values="uniqueValues"
-            :unique-values-to-subject-map="uniqueValuesToSubjectMap"
-            @update:dataTable="$emit('update:dataTable', $event)"
-            @update:heuristics="$emit('update:heuristics', $event)"
-            @update:missingValue="$emit('update:missingValue', $event)" />
+            :title="title" />
 
     </div>
 
@@ -43,21 +30,12 @@
 
     export default {
 
-        props: {
-
-            details: { type: Object, required: true },
-            title: { type: String, required: true }
-        },
-
-        inject: [
-
-            "columnToCategoryMap",
-            "dataTable"
-        ],
-
         data() {
 
             return {
+
+                details: "",
+                title: "hello",
 
                 // Category of the current annotation tab
                 category: "",
@@ -71,102 +49,8 @@
         },
 
         computed: {
-
-            ...mapGetters([
-
-                "getColumnsOfCategory"
-            ]),
-
-            filteredDataTable() {
-
-                const filteredTable = this.dataTable.original.map((row) => {
-
-                    return Object.fromEntries(
-                        Object.entries(row).filter(([columnName, rowValue]) =>
-                            this.relevantColumns.includes(columnName))
-                    );
-                });
-
-                // Return a data table where each row is filtered to only show the columns that are mapped to the given category
-                // NOTE: The original data table is used here because we want to display the original raw values
-                return filteredTable;
-            },
-
-            relevantColumns() {
-
-                // Create and return a list of columns that are categorized with this tab's category
-                const columnList = [];
-                for ( const columnName in this.columnToCategoryMap ) {
-
-                    // If this tab is an assessment tool group, make sure this column is in its toolset
-                    if ( Object.hasOwn(this.details, "groupName") &&
-                        !(this.details.tools.includes(columnName)) ) {
-                        continue;
-                    }
-
-                    if ( this.category === this.columnToCategoryMap[columnName] ) {
-                        columnList.push(columnName);
-                    }
-                }
-
-                return columnList;
-            },
-
-            uniqueValues() {
-
-                // 1. Create and return an object that maps column names to unique values from the filtered table
-                const uniqueValuesMap = {};
-                for ( const columnName of this.relevantColumns ) {
-
-                    // A. Get unique values for this column from the filtered table
-                    uniqueValuesMap[columnName] = Array.from(new Set(this.filteredDataTable.map(row => row[columnName])));
-                }
-
-                return uniqueValuesMap;
-            },
-
-            uniqueValuesToSubjectMap() {
-
-                const valuesToSubjectMap = {};
-
-                // 1. Create a map between unique values for each column and the subjects that have those values
-
-                // A. Begin with an empty map for all values in all columns
-                for ( const column in this.uniqueValues ) {
-
-                    valuesToSubjectMap[column] = {};
-
-                    for ( const value of this.uniqueValues[column] ) {
-
-                        valuesToSubjectMap[column][value] = [];
-                    }
-                }
-
-                // B. Fill in the map with subjects that have the unique values for each column
-                for ( const row of this.dataTable.original ) {
-
-                    for ( const column in valuesToSubjectMap ) {
-
-                        valuesToSubjectMap[column][row[column]].push(row[this.idField]);
-                    }
-                }
-
-                return valuesToSubjectMap;
-            }
-        },
-
-        created() {
-
-            // NOTE: The category must be set here in created or the components
-            // for 'annot-tab' will not be initialized correctly
-
-            // 1. Set the given category for this tab
-            this.category = this.details.category;
-
-            // 2. Get column marked as subject ID
-            // NOTE: the "Subject ID" category is only allowed to be applied to one column
-            this.idField = this.getColumnsOfCategory("Subject ID")[0];
         }
+
     };
 
 </script>

--- a/components/annot-tab.vue
+++ b/components/annot-tab.vue
@@ -3,7 +3,7 @@
     <div :data-cy="activeCategory">
 
         <!-- Explanation text for this annotation tab -->
-        <annot-explanation :data-cy="('annot-expl-' + activeCategory)" />
+        <annot-explanation :data-cy="('annot-expl-' + activeCategory)" :active-category="activeCategory" />
 
         <!-- Lists all the columns linked to the category of this annotation tab -->
         <annot-columns :data-cy="('annot-col-' + activeCategory)" :active-category="activeCategory" />

--- a/cypress/component/annot-tab.cy.js
+++ b/cypress/component/annot-tab.cy.js
@@ -1,0 +1,8 @@
+import annotTab from "~/components/annot-tab.vue";
+
+
+describe("annotTab", () => {
+    it("mounts", () => {
+        cy.mount(annotTab);
+    });
+});

--- a/cypress/component/annot-tab.cy.js
+++ b/cypress/component/annot-tab.cy.js
@@ -1,8 +1,34 @@
 import annotTab from "~/components/annot-tab.vue";
 
+// NOTE: because the annot-tab component is a container for other components that we are not
+// mounting here (shallowMount), the UI is always going to be empty.
+// We therefore write assertions on existence of elements, not their visibility.
+// In Cypress, elements with no width / content are considered invisible.
+
+const store = {
+    getters: {
+        getAnnotationComponent: () => (category) => "component1"
+    }
+};
+
+const props = {
+    activeCategory: "category1"
+};
 
 describe("annotTab", () => {
-    it("mounts", () => {
-        cy.mount(annotTab);
+    it("mounts understands the activeCategory prop", () => {
+        cy.mount(annotTab, {
+            propsData: props,
+            computed: store.getters
+        });
+        cy.get("[data-cy='category1']").should('exist');
+
+    });
+    it("gets the correct annotation component name from the store", () => {
+        cy.mount(annotTab, {
+            propsData: props,
+            computed: store.getters
+        });
+        cy.get("[data-cy='category1']").get("[data-cy='component1-category1']").should("exist");
     });
 });


### PR DESCRIPTION
Took over this PR from @jarmoza because this component was the last small component to be refactored (rest are pages and I/O things)

Note: the component tests are visually empty because the `annot-tab` component is just a container component for the components displayed on the annotation page. 

The component now has no internal logic or state because it's child components talk directly to the store. The only thing it is passing along is the prop for the `activeCategory`.

Closes #207