### PR TITLE
Removal of nextPageAccessible getter

### DIFF
--- a/components/next-page.vue
+++ b/components/next-page.vue
@@ -66,7 +66,6 @@
             ...mapGetters([
 
                 "nextPage",
-                "nextPageAccessible",
                 "pageAccessible"
             ]),
 
@@ -79,7 +78,7 @@
             nextPageButtonColor() {
 
                 // Bootstrap variant color of the button leading to the next page
-                return this.nextPageAccessible ? "success" : "secondary";
+                return this.pageAccessible(this.nextPage) ? "success" : "secondary";
             }
         },
 

--- a/store/index.js
+++ b/store/index.js
@@ -701,26 +701,6 @@ export const getters = {
         return nextPage;
     },
 
-    nextPageAccessible: (p_state, p_getters) => {
-
-        let nextPage = "";
-
-        switch ( p_state.currentPage ) {
-
-            case "home":
-                nextPage = "categorization";
-                break;
-            case "categorization":
-                nextPage = "annotation";
-                break;
-            case "annotation":
-                nextPage = "download";
-                break;
-        }
-
-        return p_getters.pageAccessible(nextPage);
-    },
-
     pageAccessible: (p_state, p_getters) => (p_pageName) => {
 
         let pageAccessible = false;


### PR DESCRIPTION
Upon review, it's apparent that the `nextPageAccessible` getter can be removed from the store and its usage in the `next-page` component.

This same functionality can be accessed by calling getter `pageAccessible` with the return value of getter `nextPage` as an argument.