### PR TITLE
Implement getColumnDescription getter

### DIFF
--- a/components/column-linking-table.vue
+++ b/components/column-linking-table.vue
@@ -53,6 +53,7 @@
 
                 "categoryClasses",
                 "columns",
+                "getColumnDescription",
                 "columnToCategoryMap"
             ]),
 
@@ -62,7 +63,7 @@
 
                     category: this.columnToCategoryMap[column],
                     column: column.name,
-                    description: column.description
+                    description: this.getColumnDescription(column.name)
                 }));
             }
         },

--- a/cypress/component/column-linking-table.cy.js
+++ b/cypress/component/column-linking-table.cy.js
@@ -4,91 +4,104 @@ import ColumnLinkingTable from "~/components/column-linking-table.vue";
 // Documentation for testing Vue events of components
 // https://docs.cypress.io/guides/component-testing/events-vue
 
-// Mocks
-
-const store = {
-    commit: () => {},
-    getters: {
-
-        categories: () => {
-
-            return [
-
-                "Subject ID",
-                "Age",
-                "Sex",
-                "Diagnosis",
-                "Assessment Tool"
-            ];
-        },
-
-        categoryClasses: () => {
-
-            return {
-
-                "Subject ID": "category-style-0",
-                "Age": "category-style-1",
-                "Sex": "category-style-2",
-                "Diagnosis": "category-style-3",
-                "Assessment Tool": "category-style-4"
-            };
-        },
-
-        columns: () => {
-
-            return [
-
-                { name: "participant_id", description: "" },
-                { name: "age", description: "age of the participant" },
-                { name: "sex", description: "sex of the participant as reported by the participant" },
-                { name: "group", description: "diagnostic status determined by the study clinician at baseline" },
-                { name: "group_dx", description: "specific diagnosis determined by the study clinician at baseline" },
-                { name: "number_comorbid_dx", description: "a number of diagnoses comorbid with UD (e.g., GAD, PTSD)" },
-                { name: "medload", description: "reflects the number of dosage of psychotropic medications taken by participants. Higher numbers correspond to more medications and/or higher medication dosage " },
-                { name: "iq", description: "IQ derived based on the NART assessment." },
-                { name: "session", description: "scanning session" }
-            ];
-        },
-
-        columnToCategoryMap: () => {
-
-            return {
-
-                "participant_id": null,
-                "age": null,
-                "sex": null,
-                "group": null,
-                "group_dx": null,
-                "number_comorbid_dx": null,
-                "medload": null,
-                "iq": null,
-                "session": null
-            };
-        }
-    },
-
-    mutations: {
-        alterColumnCategoryMapping: () => (activeCategory, columnName) => {}
-    }
-};
-
-const props = {
-
-    activeCategory: "Subject ID"
-};
-
 // Tests
 
-describe("Tests basic functionality of the table that links categories with data table columns", () => {
+describe("The column-linking-table component", () => {
+    // Initialize the mocks
+    let store;
+    let props;
 
-    it("Alter link relation (add/remove) between a column and a category", () => {
+    beforeEach(() => {
+        // Redefine the mocks
+        store = {
+            commit: () => {},
+            getters: {
+
+                categories: () => {
+
+                    return [
+
+                        "Subject ID",
+                        "Age",
+                        "Sex"
+                    ];
+                },
+
+                categoryClasses: () => {
+
+                    return {
+
+                        "Subject ID": "category-style-0",
+                        "Age": "category-style-1",
+                        "Sex": "category-style-2"
+                    };
+                },
+
+                columns: () => {
+
+                    return [
+
+                        { name: "participant_id" },
+                        { name: "age" },
+                        { name: "sex" }
+                    ];
+                },
+
+                getColumnDescription: () => (columnName) => {
+                    return "descriptions help";
+                },
+
+                columnToCategoryMap: () => {
+
+                    return {
+
+                        "participant_id": null,
+                        "age": null,
+                        "sex": null
+                    };
+                }
+            },
+
+            mutations: {
+                alterColumnCategoryMapping: () => (activeCategory, columnName) => {}
+            }
+        };
+
+        props = {
+
+            activeCategory: "Subject ID"
+        };
+
+    });
+
+    it("correctly displays columns and descriptions", () => {
+        cy.mount(ColumnLinkingTable, {
+
+            mocks: {
+
+                $store: store
+            },
+
+            computed: store.getters,
+
+            plugins: ["bootstrap-vue"],
+
+            propsData: props
+        });
+
+        for ( const columnName of ["participant_id", "age", "sex"] ) {
+            cy.get("[data-cy='column-linking-table-table']").contains(columnName).parent().as("targetRow");
+            cy.get("@targetRow").contains("descriptions help");
+        }
+
+    });
+    it("can alter link relation (add/remove) between a column and a category", () => {
 
         // 0. The first category and column
         const participantIDColumn = store.getters.columns()[0].name;
         const subjectIDCategory = store.getters.categories()[0];
 
         // 1. Arrange - Set up the spy, mount the component, and bind the spy to it
-        const onColumnNameClickedSpy = cy.spy().as("onColumnNameClickedSpy");
         cy.spy(store, 'commit').as('commitSpy');
         cy.mount(ColumnLinkingTable, {
 

--- a/cypress/unit/store-getter-getColumnDescription.cy.js
+++ b/cypress/unit/store-getter-getColumnDescription.cy.js
@@ -1,0 +1,24 @@
+import { getters } from "~/store/index-refactor";
+
+
+const state = {
+    dataDictionary : {
+        annotated: {
+            "describedColumn": {
+                description: "This is my first column"
+            },
+            "lazyColumn": {}
+        }
+    }
+};
+
+describe("getColumnDescription", () => {
+    it("returns description for a column if one exists", () => {
+        const result = getters.getColumnDescription(state, "describedColumn");
+        expect(result).to.be.equal("This is my first column");
+    });
+    it("returns an empty string if no descripton exists", () => {
+        const result = getters.getColumnDescription(state, "lazyColumn");
+        expect(result).to.be.empty;
+    });
+});

--- a/store/index-refactor.js
+++ b/store/index-refactor.js
@@ -3,7 +3,14 @@ import Vue from "vue";
 
 export const state = () => ({
     categories: {},
-    columnToCategoryMapping: {}
+    columnToCategoryMapping: {},
+    dataDictionary: {
+        // stores the data dictionary loaded by the user (if available) in userProvided
+        // and stores the extended version created during annotation in annotated.
+        // We use this both as a state object and as the template for the downloadable data dictionary
+        userProvided: {},
+        annotated: {}
+    }
 
 });
 
@@ -11,8 +18,15 @@ export const getters = {
 
     getCategoryNames (p_state) {
         return Object.keys(p_state.categories);
+    },
+    getColumnDescription (p_state, p_columnName) {
+        if ( Object.hasOwn(p_state.dataDictionary.annotated[p_columnName], "description") ) {
+            return p_state.dataDictionary.annotated[p_columnName].description;
+        }
+        else {
+            return "";
+        }
     }
-
 };
 
 


### PR DESCRIPTION
There is a bit more in this PR than just the normal refactor. The reason is that adding a new test for the 
`column-linking-component` somehow broke the existing component test in a way I didn't understand.
The original `column-linking-component` test passed when forced to run alone `it.only`, but could not wrap the
`commit` function on the `store` object in a `cy.spy` when it was run second after the new test. 

I think this may be because running the first test somehow changes the mocked `store` object in a way
that affects subsequent test. I was not able to debug this though, the `store` object looked normal to me.
As a workaround, I have moved the mocked store into a `beforeEach` statement to make sure every test
gets passed the same `store` object. 

There may be better ways of doing this, and I think we should research these separately. I made https://github.com/neurobagel/annotation_tool/issues/288 to track this.

Closes #253