### PR TITLE
setCurrentPage mutation + unit test for store refactor

### DIFF
--- a/cypress/unit/store-mutation-setCurrentPage.cy.js
+++ b/cypress/unit/store-mutation-setCurrentPage.cy.js
@@ -1,0 +1,24 @@
+import { mutations } from "~/store/index-refactor";
+
+let state = {};
+
+describe("setCurrentPage", () => {
+
+    beforeEach(() => {
+
+        // Setup
+        state = {
+
+            currentPage: "home"
+        };
+    });
+
+    it("Set the annotation tool's current page", () => {
+
+        // Act
+        mutations.setCurrentPage(state, "categorization");
+
+        // Assert
+        expect(state.currentPage).to.equal("categorization");
+    });
+});

--- a/store/index-refactor.js
+++ b/store/index-refactor.js
@@ -7,6 +7,8 @@ export const state = () => ({
 
     columnToCategoryMapping: {},
 
+    currentPage: "home",
+
     dataDictionary: {
 
         // stores the data dictionary loaded by the user (if available) in userProvided
@@ -77,5 +79,10 @@ export const mutations = {
         // Column to category map lists all columns as keys with default value of null
         p_state.columnToCategoryMapping =
             Object.fromEntries(p_columns.map((column) => [column, null]));
+    },
+
+    setCurrentPage(p_state, p_pageName) {
+
+        p_state.currentPage = p_pageName;
     }
 };


### PR DESCRIPTION
This is a straightforward implementation for both the mutation and test. The mutation itself is currently only used by the `tool-navbar` and the `next-page` components.

This addresses #265 