### PR TITLE
Implementation of nextPage getter for refactor + unit test

### DIFF
--- a/components/next-page.vue
+++ b/components/next-page.vue
@@ -16,7 +16,7 @@
                 data-cy="button-nextpage"
                 :disabled="!pageData[getNextPage].accessible"
                 :to="'/' + pageData[getNextPage].location"
-                :variant="getNextPageButtonColor"
+                :variant="nextPageButtonColor"
                 @click="setCurrentPage(getNextPage)">
                 {{ uiText.button[currentPage] }}
             </b-button>

--- a/components/next-page.vue
+++ b/components/next-page.vue
@@ -14,10 +14,10 @@
             <b-button
                 class="float-right"
                 data-cy="button-nextpage"
-                :disabled="!pageData[nextPage].accessible"
-                :to="'/' + pageData[nextPage].location"
-                :variant="nextPageButtonColor"
-                @click="setCurrentPage(nextPage)">
+                :disabled="!pageData[getNextPage].accessible"
+                :to="'/' + pageData[getNextPage].location"
+                :variant="getNextPageButtonColor"
+                @click="setCurrentPage(getNextPage)">
                 {{ uiText.button[currentPage] }}
             </b-button>
         </b-col>
@@ -65,7 +65,7 @@
 
             ...mapGetters([
 
-                "nextPage",
+                "getNextPage",
                 "pageAccessible"
             ]),
 

--- a/components/next-page.vue
+++ b/components/next-page.vue
@@ -78,7 +78,7 @@
             nextPageButtonColor() {
 
                 // Bootstrap variant color of the button leading to the next page
-                return this.pageAccessible(this.nextPage) ? "success" : "secondary";
+                return this.pageAccessible(this.getNextPage) ? "success" : "secondary";
             }
         },
 

--- a/cypress/unit/store-getter-getNextPage.cy.js
+++ b/cypress/unit/store-getter-getNextPage.cy.js
@@ -1,0 +1,30 @@
+import { getters } from "~/store/index-refactor";
+
+let state = {};
+
+describe("getNextPage", () => {
+
+    beforeEach(() => {
+
+        // Setup
+        state = {
+
+            currentPage: "home"
+        };
+    });
+
+    it("Checks each next page after given page is correct", () => {
+
+        // Setup
+        let pageNames = ["home", "categorization", "annotation", "download"];
+
+        for ( let index = 0; index < pageNames.length - 1; index++ ) {
+
+            // Act
+            state.currentPage = pageNames[index];
+
+            // Assert
+            expect(getters.getNextPage(state, pageNames[index])).to.equal(pageNames[index + 1]);
+        }
+    });
+});

--- a/store/index-refactor.js
+++ b/store/index-refactor.js
@@ -40,6 +40,26 @@ export const getters = {
         return ( 0 === p_state.dataTable.length ) ? [] : Object.keys(p_state.dataTable[0]);
     },
 
+    getNextPage(p_state) {
+
+        let nextPage = "";
+
+        switch ( p_state.currentPage ) {
+
+            case "home":
+                nextPage = "categorization";
+                break;
+            case "categorization":
+                nextPage = "annotation";
+                break;
+            case "annotation":
+                nextPage = "download";
+                break;
+        }
+
+        return nextPage;
+    },
+
     getValueDescription (p_state, p_columnName, p_value) {
         // Returns the description of a value in a column, if that description exists
         // Otherwise it returns an empty string


### PR DESCRIPTION
This PR addresses #260. This getter makes use of the annotation tool's implicit page order. E.g. Given the current page of the app, what is the next (or following) page?

The `next-page` component has been altered to make use of the new getter name style `get*`.

The unit test sets each page as the current page and makes sure the proper 'next page' is being returned from the getter.