### PR TITLE
Implementation of isPageAccessible getter for refactor

### DIFF
--- a/components/next-page.vue
+++ b/components/next-page.vue
@@ -5,7 +5,7 @@
         <b-col class="text-right" cols="4">
 
             <!-- Optional instructions to remind user of criteria to proceed to the next page -->
-            <p class="instructions-text" v-if="!pageAccessible(currentPage)">
+            <p class="instructions-text" v-if="!isPageAccessible(currentPage)">
                 {{ uiText.instructions[currentPage] }}
             </p>
 
@@ -65,8 +65,8 @@
 
             ...mapGetters([
 
-                "nextPage",
-                "pageAccessible"
+                "isPageAccessible",
+                "nextPage"
             ]),
 
             ...mapState([
@@ -78,7 +78,7 @@
             nextPageButtonColor() {
 
                 // Bootstrap variant color of the button leading to the next page
-                return this.pageAccessible(this.nextPage) ? "success" : "secondary";
+                return this.isPageAccessible(this.nextPage) ? "success" : "secondary";
             }
         },
 

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -24,7 +24,7 @@
                         :active="currentPageName === navItem.fullName"
                         :class="getNavItemColor(navItem)"
                         :data-cy="'menu-item-' + navItem.pageName"
-                        :disabled="!pageAccessible(navItem.pageName)"
+                        :disabled="!isPageAccessible(navItem.pageName)"
                         :key="navItem.pageName"
                         :to="navItem.location"
                         @click="setCurrentPage(navItem.pageName)">
@@ -70,7 +70,7 @@
 
             ...mapGetters([
 
-                "pageAccessible"
+                "isPageAccessible"
             ]),
 
             ...mapState([

--- a/cypress/unit/store-getter-isPageAccessible.cy.js
+++ b/cypress/unit/store-getter-isPageAccessible.cy.js
@@ -1,0 +1,75 @@
+import { getters } from "~/store/index-refactor";
+
+let state = {};
+
+describe("isPageAccessible", () => {
+
+    beforeEach(() => {
+
+        // Setup
+        state = {
+
+            annotationCount: 1,
+
+            columnToCategoryMapping: {
+
+                "column1Name": "Subject ID"
+            },
+
+            dataTable: [
+
+                {
+                    "column1Name": "value1", "column2Name": "value2"
+                },
+                {
+                    "column1Name": "value3", "column2Name": "value4"
+                }
+            ]
+        };
+    });
+
+    it("Test page accessibility via the index page", () => {
+
+        // Setup
+        let nextPage = "categorization";
+
+        // Assert
+        expect(getters.isPageAccessible(state, nextPage)).to.be.true;
+
+        // Setup
+        state.dataTable = [];
+
+        // Assert
+        expect(getters.isPageAccessible(state, nextPage)).to.be.false;
+    });
+
+    it("Test page accessibility via the categorization page", () => {
+
+        // Setup
+        let nextPage = "annotation";
+
+        // Assert
+        expect(getters.isPageAccessible(state, nextPage)).to.be.true;
+
+        // Setup
+        state.columnToCategoryMapping = {};
+
+        // Assert
+        expect(getters.isPageAccessible(state, nextPage)).to.be.false;
+    });
+
+    it("Test page accessibility via the annotation page", () => {
+
+        // Setup
+        let nextPage = "download";
+
+        // Assert
+        expect(getters.isPageAccessible(state, nextPage)).to.be.true;
+
+        // Setup
+        state.annotationCount = 0;
+
+        // Assert
+        expect(getters.isPageAccessible(state, nextPage)).to.be.false;
+    });
+});

--- a/store/index-refactor.js
+++ b/store/index-refactor.js
@@ -48,6 +48,58 @@ export const getters = {
             return "";
         }
         return description;
+    },
+
+    isPageAccessible: (p_state, p_pageName) => {
+
+        let pageAccessible = false;
+
+        switch ( p_pageName ) {
+
+            case "home":
+
+                // Landing page is always accessible
+                pageAccessible = true;
+                break;
+
+            case "categorization":
+
+                // Categorization page is accessible if a data table has been uploaded
+                pageAccessible = p_state.dataTable.length > 0;
+
+                break;
+
+            case "annotation": {
+
+                // 1. Determine if at least one column has been linked to a category
+                const linkCount = Object.values(p_state.columnToCategoryMapping).filter(
+                    category => ( null !== category )).length;
+                const categorizationStatus = linkCount > 0;
+
+                // 2. Make sure one (and only one) column has been categorized as 'Subject ID'
+                let subjectIDFound = 0;
+                for ( const column in p_state.columnToCategoryMapping ) {
+                    if ( "Subject ID" === p_state.columnToCategoryMapping[column] ) {
+                        subjectIDFound += 1;
+                    }
+                }
+                const singleSubjectIDColumn = ( 1 === subjectIDFound );
+
+                // Annotation page is only accessible if at least one column has
+                // been categorized and if one (and only one) column has been categorized as 'Subject ID'
+                pageAccessible = categorizationStatus && singleSubjectIDColumn;
+
+                break;
+            }
+
+            case "download":
+
+                pageAccessible = p_state.annotationCount > 0;
+
+                break;
+        }
+
+        return pageAccessible;
     }
 };
 

--- a/store/index-refactor.js
+++ b/store/index-refactor.js
@@ -72,18 +72,13 @@ export const getters = {
             case "annotation": {
 
                 // 1. Determine if at least one column has been linked to a category
-                const linkCount = Object.values(p_state.columnToCategoryMapping).filter(
-                    category => ( null !== category )).length;
-                const categorizationStatus = linkCount > 0;
+                const categorizationStatus = Object.values(p_state.columnToCategoryMapping)
+                                                   .some(category =>  null !== category );
 
                 // 2. Make sure one (and only one) column has been categorized as 'Subject ID'
-                let subjectIDFound = 0;
-                for ( const column in p_state.columnToCategoryMapping ) {
-                    if ( "Subject ID" === p_state.columnToCategoryMapping[column] ) {
-                        subjectIDFound += 1;
-                    }
-                }
-                const singleSubjectIDColumn = ( 1 === subjectIDFound );
+                const singleSubjectIDColumn = ( 1 === Object.values(p_state.columnToCategoryMapping)
+                                                            .filter(category => "Subject ID" === category)
+                                                            .length );
 
                 // Annotation page is only accessible if at least one column has
                 // been categorized and if one (and only one) column has been categorized as 'Subject ID'


### PR DESCRIPTION
This PR addresses #261.

The implementation of this boolean getter is a bit more complex than most in our store. `isPageAccessible` is a tweaked version of `pageAccessible` from the previous store. It checks the conditions necessary for access to the given page passed to it.

The tweaks from `pageAccessible` reflect the current state of the implementation of the categorization page (where assessment tools and tool groups are to be reimplemented soon). Currently one should only need at least one category-linked column and for the 'Subject ID' category to be used at least once to progress to the `annotation` page. Secondly, since we do not yet have a good conditional metric for moving to the `download` page, a value `annotationCount` is used. (To move to the categorization page, a non-empty `dataTable` must be present.)

The unit tests implement check for moving to the `categorization` page, `annotation` page, and `download` page in two ways. First, _with_ the sufficient input and then secondly _without_ the sufficient input.