### PR TITLE
action to process a new dataTable

### DIFF
--- a/cypress/unit/store-action-processDataTable.cy.js
+++ b/cypress/unit/store-action-processDataTable.cy.js
@@ -1,0 +1,32 @@
+import { actions, getters, mutations } from "~/store/index-refactor";
+
+const context = {
+    commit: () => {},
+    state: {
+        dataTable: []
+    },
+    getters: getters,
+    mutations: mutations
+};
+const payload = {
+    data: [
+        ["col1", "col2"],
+        ["val1", "val2"],
+        ["val21", "val22"]
+    ],
+    filename: "myFile.tsv"
+};
+
+describe("processDataTable", () => {
+
+    it("accepts the correct arguments and calls all the expected mutations", () => {
+        cy.spy(context, 'commit');
+
+        actions.processDataTable(context, payload);
+        // Here we only want to ensure that the mutations are called at all
+        // Whether they work correctly is tested in their respective unit tests
+        expect(context.commit).to.be.calledWith("setDataTable");
+        expect(context.commit).to.be.calledWith("initializeColumnToCategoryMap");
+        expect(context.commit).to.be.calledWith("initializeDataDictionary");
+    });
+});

--- a/cypress/unit/store-mutation-initializeDataDictionary.cy.js
+++ b/cypress/unit/store-mutation-initializeDataDictionary.cy.js
@@ -1,0 +1,46 @@
+import { mutations } from "~/store/index-refactor";
+
+let state = {};
+
+describe('initializeDataDictionary', () => {
+    beforeEach(() => {
+        state = {
+            dataTable: [
+                { "col1": "val1", "col2": "val2" },
+                { "col1": "val21", "col2": "val22" }
+            ],
+            dataDictionary: {
+                annotated: {}
+            }
+        };
+    });
+
+    it('initializes a new data dictionary when none is defined', () => {
+        mutations.initializeDataDictionary(state);
+
+        expect(state.dataDictionary.annotated).to.deep.equal({
+            "col1": {
+                "description": ""
+            },
+            "col2": {
+                "description": ""
+            }
+        });
+    });
+    it('overwrites existing data dictionary when one is already defined', () => {
+        state.dataDictionary.annotated = {
+            "this": "annotation",
+            "is": "no longer needed"
+        };
+        mutations.initializeDataDictionary(state);
+
+        expect(state.dataDictionary.annotated).to.deep.equal({
+            "col1": {
+                "description": ""
+            },
+            "col2": {
+                "description": ""
+            }
+        });
+    });
+});

--- a/cypress/unit/store-mutation-setDataTable.cy.js
+++ b/cypress/unit/store-mutation-setDataTable.cy.js
@@ -1,0 +1,61 @@
+import { mutations } from "~/store/index-refactor";
+
+let state = {};
+
+describe('setDataTable', () => {
+  beforeEach(() => {
+    state = {
+      dataTable: []
+    };
+  });
+
+  it('converts and stores a new dataTable in the state', () => {
+    mutations.setDataTable(state, [
+      ["col1", "col2"],
+      ["val1", "val2"],
+      ["val21", "val22"]
+    ]);
+    expect(state.dataTable).to.deep.equal([
+      { "col1": "val1", "col2": "val2" },
+      { "col1": "val21", "col2": "val22" }
+    ]);
+  });
+
+  it('strips away empty lines', () => {
+    mutations.setDataTable(state, [
+      ["col1", "col2"],
+      ["", ""],
+      ["val21", "val22"],
+      [""]
+    ]);
+    expect(state.dataTable).to.deep.equal([
+      { "col1": "val21", "col2": "val22" }
+    ]);
+  });
+
+  it("warns and then truncates rows that are longer than the header", () => {
+    mutations.setDataTable(state, [
+      ["col1", "col2"],
+      ["val1", "val2"],
+      ["val21", "val22", "I'm too long"]
+    ]);
+    // TODO: find a way to actually assert the warning
+    expect(state.dataTable).to.deep.equal([
+      { "col1": "val1", "col2": "val2" },
+      { "col1": "val21", "col2": "val22" }
+    ]);
+  });
+
+  it("warns but parses rows that are shorter than the header", () => {
+    mutations.setDataTable(state, [
+      ["col1", "col2"],
+      ["val1", "val2"],
+      ["too short"]
+    ]);
+    // TODO: find a way to actually assert the warning
+    expect(state.dataTable).to.deep.equal([
+      { "col1": "val1", "col2": "val2" },
+      { "col1": "too short" }
+    ]);
+  });
+});

--- a/store/index-refactor.js
+++ b/store/index-refactor.js
@@ -103,5 +103,34 @@ export const mutations = {
     setCurrentPage(p_state, p_pageName) {
 
         p_state.currentPage = p_pageName;
+    },
+
+    setDataTable(p_state, p_dataTable) {
+
+        const columnNames = p_dataTable[0];
+        let dataTable = [];
+        
+        for ( const [rowIndex, row] of p_dataTable.slice(1).entries() ) {
+            // If the row is empty, we don't want it in our dataTable
+            if ( "" === row.join("").trim() ) {
+                continue;
+            } else if ( row.length < columnNames.length ) {
+                console.warn("WARNING: tsv row " + parseInt(rowIndex) + " has fewer columns than the tsv header!");
+            }
+
+            let rowArray = [];
+            for ( const [colIndex, value] of row.entries() ) {
+                // Rows that are longer than the header should be truncated
+                if ( colIndex >= columnNames.length ) {
+                    console.warn("WARNING: tsv row " + parseInt(rowIndex) + " has more columns than the tsv header!");
+                    continue;
+                        }
+
+                rowArray.push([columnNames[colIndex], value]);
+                    }
+            dataTable.push(Object.fromEntries(rowArray));
+        }
+
+        p_state.dataTable = dataTable;
     }
 };

--- a/store/index-refactor.js
+++ b/store/index-refactor.js
@@ -100,6 +100,15 @@ export const mutations = {
             Object.fromEntries(p_columns.map((column) => [column, null]));
     },
 
+    initializeDataDictionary(p_state) {
+
+        let dataDictionary = {};
+        for ( const columnName of Object.keys(p_state.dataTable[0]) ) {
+            dataDictionary[columnName] = {"description": ""};
+        }
+        p_state.dataDictionary.annotated = Object.assign({}, dataDictionary);
+    },
+
     setCurrentPage(p_state, p_pageName) {
 
         p_state.currentPage = p_pageName;

--- a/store/index-refactor.js
+++ b/store/index-refactor.js
@@ -73,6 +73,20 @@ export const getters = {
 };
 
 
+export const actions = {
+
+    processDataTable( { state, commit, getters }, { data, filename }) {
+
+        // This action is dispatched when a new dataTable is loaded by the user.
+        // This indicates to us that the user wants to reset the app and begin a new
+        // annotation procedure from scratch. The needed steps are handled by this action.
+
+        commit("setDataTable", data);
+        commit("initializeColumnToCategoryMap", getters.getColumnNames);
+        commit("initializeDataDictionary");
+    }
+};
+
 export const mutations = {
 
     /**
@@ -118,7 +132,7 @@ export const mutations = {
 
         const columnNames = p_dataTable[0];
         let dataTable = [];
-        
+
         for ( const [rowIndex, row] of p_dataTable.slice(1).entries() ) {
             // If the row is empty, we don't want it in our dataTable
             if ( "" === row.join("").trim() ) {
@@ -133,10 +147,10 @@ export const mutations = {
                 if ( colIndex >= columnNames.length ) {
                     console.warn("WARNING: tsv row " + parseInt(rowIndex) + " has more columns than the tsv header!");
                     continue;
-                        }
+                }
 
                 rowArray.push([columnNames[colIndex], value]);
-                    }
+            }
             dataTable.push(Object.fromEntries(rowArray));
         }
 


### PR DESCRIPTION
Closes #256 

This PR adds:

- the `processDataTable` action (#256)
- and also a new mutation `setDataTable` to process and then store a provided dataTable
- and also a new mutation `initializeDataDictionary` to create a skeleton data dictionary from a stored dataTable

with tests. The two mutations are meant to be called only from inside the store. There isn't anything to prevent a component to call the mutations directly (other than us not doing that). 

The test for the action is very limited, it only checks if the correct mutations are being committed. The reason behind this is that because the mutations are already tested via their unit tests, and because they are mocked during the unit test of the action, it would be pretty tricky to test that the action actually has the desired effect on the state. I think what we've realized here is that action tests are somewhere between unit and integration tests. 