### PR TITLE
Data dictionary refactor for Store refactor + Tests

### DIFF
--- a/cypress/unit/store-mutations-setDataDictionary.cy.js
+++ b/cypress/unit/store-mutations-setDataDictionary.cy.js
@@ -1,0 +1,73 @@
+import { mutations } from "~/store/index-refactor";
+
+let state = {};
+
+describe("setDataDictionary", () => {
+
+    beforeEach(() => {
+
+        // Setup
+        state = {
+
+            dataDictionary: {
+
+                "age": {
+
+                    "Description": "age of the participant",
+                    "Units": "years"
+                },
+                "sex": {
+
+                    "Description": "sex of the participant as reported by the participant",
+                    "Levels": {
+                        "M": "male",
+                        "F": "female"
+                    }
+                }
+            },
+
+            dataTable: [
+
+                {
+                    "age": "value1", "sex": "value2"
+                },
+                {
+                    "age": "value3", "sex": "value4"
+                }
+            ]
+        };
+    });
+
+    it("Are new key/value pairs in the uploaded dictionary not added to the data dictionary?", () => {
+
+        // Act
+        mutations.setDataDictionary(state,
+            { "group": { "key1": "value1" } },
+            ["age", "sex"]);
+
+        // Assert
+        expect(state.dataDictionary).to.not.contain.keys("group");
+    });
+
+    it("Has every new key/value pair at least one level deep in the uploaded dictionary been added to the state dictionary, if the key was already present in the state dictionary", () => {
+
+        // Act
+        mutations.setDataDictionary(state,
+            { "age": { "Units": "minutes" } },
+            ["age", "sex"]);
+
+        // Assert
+        expect(state.dataDictionary.age["Units"]).to.equal("minutes");
+    });
+
+    it("Has every new key/value pair two levels deep in the uploaded dictionary been added to the state dictionary, if the key was already present in the state dictionary", () => {
+
+        // Act
+        mutations.setDataDictionary(state,
+            { "sex": { "Levels": { "NB": "Non-binary" }} },
+            ["age", "sex"]);
+
+        // Assert
+        expect(state.dataDictionary.sex["Levels"]).to.contain.keys("NB");
+    });
+});

--- a/cypress/unit/store-mutations-setDataDictionary.cy.js
+++ b/cypress/unit/store-mutations-setDataDictionary.cy.js
@@ -38,7 +38,7 @@ describe("setDataDictionary", () => {
         };
     });
 
-    it("Are new key/value pairs in the uploaded dictionary not added to the data dictionary?", () => {
+    it("New columns in the uploaded dictionary should not be added to the state data dictionary?", () => {
 
         // Act
         mutations.setDataDictionary(state,
@@ -49,7 +49,7 @@ describe("setDataDictionary", () => {
         expect(state.dataDictionary).to.not.contain.keys("group");
     });
 
-    it("Has every new key/value pair at least one level deep in the uploaded dictionary been added to the state dictionary, if the key was already present in the state dictionary", () => {
+    it("New string/string key/value pairs for columns should replace values in the state data dictionary", () => {
 
         // Act
         mutations.setDataDictionary(state,
@@ -57,17 +57,19 @@ describe("setDataDictionary", () => {
             ["age", "sex"]);
 
         // Assert
-        expect(state.dataDictionary.age["Units"]).to.equal("minutes");
+        expect(state.dataDictionary["age"]["Units"]).to.equal("minutes");
     });
 
-    it("Has every new key/value pair two levels deep in the uploaded dictionary been added to the state dictionary, if the key was already present in the state dictionary", () => {
+    it("New string/object key/value pairs in the uploaded dictionary should update/retain values in the state data dictionary", () => {
 
         // Act
         mutations.setDataDictionary(state,
-            { "sex": { "Levels": { "NB": "Non-binary" }} },
+            { "sex": { "Levels": { "M": "male", "F": "female", "NB": "non-binary" }} },
             ["age", "sex"]);
 
         // Assert
-        expect(state.dataDictionary.sex["Levels"]).to.contain.keys("NB");
+        expect(state.dataDictionary["sex"]["Levels"]).to.contain.keys("M");
+        expect(state.dataDictionary["sex"]["Levels"]).to.contain.keys("F");
+        expect(state.dataDictionary["sex"]["Levels"]).to.contain.keys("NB");
     });
 });

--- a/store/index-refactor.js
+++ b/store/index-refactor.js
@@ -35,12 +35,12 @@ export const getters = {
             return "";
         }
     },
-    
+
     getColumnNames(p_state) {
-    
+
         return ( 0 === p_state.dataTable.length) ? [] : Object.keys(p_state.dataTable[0] );
     },
-    
+
     getNextPage(p_state) {
 
         let nextPage = "";
@@ -122,6 +122,11 @@ export const getters = {
 
 export const actions = {
 
+    processDataDictionary( { state, commit, getters }, { data, filename }) {
+
+        commit("setDataDictionary", data, getters.getColumnNames);
+    },
+
     processDataTable( { state, commit, getters }, { data, filename }) {
 
         // This action is dispatched when a new dataTable is loaded by the user.
@@ -164,15 +169,58 @@ export const mutations = {
     initializeDataDictionary(p_state) {
 
         let dataDictionary = {};
+
         for ( const columnName of Object.keys(p_state.dataTable[0]) ) {
+
             dataDictionary[columnName] = {"description": ""};
         }
+
         p_state.dataDictionary.annotated = Object.assign({}, dataDictionary);
     },
 
     setCurrentPage(p_state, p_pageName) {
 
         p_state.currentPage = p_pageName;
+    },
+
+    setDataDictionary(p_state, p_newDataDictionary, p_storeColumns) {
+
+        console.log("In setDataDictionary");
+
+        // Add any new values from the new, uploaded dictionary for existing
+        // keys in the store dictionary
+        // NOTE: Currently only looks two levels deep in the data dictionary
+        for ( const column of p_storeColumns ) {
+
+            console.log(`Looking at column: ${column}`);
+
+            if ( column in p_newDataDictionary ) {
+
+                console.log(`Shared column ${column}`);
+
+                // Level 1
+                for ( const key in p_newDataDictionary.column ) {
+
+                    console.log(`Looking at newDataDictionary.${column}`);
+
+                    if ( !(key in p_storeColumns.column) ) {
+
+                        Vue.set(state.dataDictionary.column, key, p_newDataDictionary.column.key);
+                    }
+
+                    // Level 2
+                    for ( const subkey in p_newDataDictionary.column.key ) {
+
+                        if ( !(subkey in p_newDataDictionary.column.key) ) {
+
+                            Vue.set(state.dataDictionary.column.key, subkey, p_newDataDictionary.column.key.subkey);
+                        }
+                    }
+                }
+            }
+        }
+
+        console.log(`After setDataDictionary, dataDictionary: ${JSON.stringify(p_state.dataDictionary)}`);
     },
 
     setDataTable(p_state, p_dataTable) {

--- a/store/index-refactor.js
+++ b/store/index-refactor.js
@@ -185,42 +185,17 @@ export const mutations = {
 
     setDataDictionary(p_state, p_newDataDictionary, p_storeColumns) {
 
-        console.log("In setDataDictionary");
-
-        // Add any new values from the new, uploaded dictionary for existing
-        // keys in the store dictionary
-        // NOTE: Currently only looks two levels deep in the data dictionary
+        // Update values to existing columns in the data dictionary, but ignore any new columns
         for ( const column of p_storeColumns ) {
-
-            console.log(`Looking at column: ${column}`);
 
             if ( column in p_newDataDictionary ) {
 
-                console.log(`Shared column ${column}`);
+                for ( const key in p_newDataDictionary[column] ) {
 
-                // Level 1
-                for ( const key in p_newDataDictionary.column ) {
-
-                    console.log(`Looking at newDataDictionary.${column}`);
-
-                    if ( !(key in p_storeColumns.column) ) {
-
-                        Vue.set(state.dataDictionary.column, key, p_newDataDictionary.column.key);
-                    }
-
-                    // Level 2
-                    for ( const subkey in p_newDataDictionary.column.key ) {
-
-                        if ( !(subkey in p_newDataDictionary.column.key) ) {
-
-                            Vue.set(state.dataDictionary.column.key, subkey, p_newDataDictionary.column.key.subkey);
-                        }
-                    }
+                    Vue.set(p_state.dataDictionary[column], key, p_newDataDictionary[column][key]);
                 }
             }
         }
-
-        console.log(`After setDataDictionary, dataDictionary: ${JSON.stringify(p_state.dataDictionary)}`);
     },
 
     setDataTable(p_state, p_dataTable) {


### PR DESCRIPTION
Here's the final piece of phase 1 of our refactor of the store.

**Refactor Implementation**

As described in #257, this PR implements two store methods: the action `processDataTable` and mutation `setDataTable`. (`processDataTable` utilizes the getter `getColumns` for the update that occurs to the data dictionary via `setDataTable`.)

It is understood that initialization of the data dictionary will only occur with the upload of a new data table via action `processDataTable` fired via file selection on the index page. This creates a skeleton dictionary that only lists blank entries for each of the columns defined in the uploaded 

Any new column in the uploaded data dictionary will be ignored as this was not in the original data table. All values for extant columns in the original data table will however be overwritten. (This re: @surchs 's [latest comment](https://github.com/neurobagel/annotation_tool/issues/257#issuecomment-1384309931).) That latter ability does leave open the possibility that a user may accidentally overwrite annotations. That is a 'let-the-user-beware' ability, but can and should probably be discussed further here.

**Tests**

1. Ignore new columns in a newly uploaded data dictionary (`setDataDictionary` will only be called via `processDataDictionary` - which will be fired via file selection on the index page.)
2. Ensures simple string to string key-value pairs for columns are updated/added from a newly uploaded data dictionary
3. Ensures all keys are retained and new ones added/updated for string to object key-value pairs (and the objects' underlying string to string key-value pairs).