### PR TITLE
Navbar/next page button/page accessibility update for refactor

### DIFF
--- a/components/next-page.vue
+++ b/components/next-page.vue
@@ -14,7 +14,7 @@
             <b-button
                 class="float-right"
                 data-cy="button-nextpage"
-                :disabled="!pageData[getNextPage].accessible"
+                :disabled="!isPageAccessible(pageData[getNextPage].pageName)"
                 :to="'/' + pageData[getNextPage].location"
                 :variant="nextPageButtonColor"
                 @click="setCurrentPage(getNextPage)">

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -24,7 +24,7 @@
                         :active="currentPageName === navItem.fullName"
                         :class="getNavItemColor(navItem)"
                         :data-cy="'menu-item-' + navItem.pageName"
-                        :disabled="!isPageAccessible(navItem.pageName)"
+                        :disabled="!navItem.accessible"
                         :key="navItem.pageName"
                         :to="navItem.location"
                         @click="setCurrentPage(navItem.pageName)">
@@ -52,6 +52,9 @@
     // Fields listed in mapState below can be found in the store (index.js)
     import { mapState } from "vuex";
 
+    // Allows for reference to store actions (index.js)
+    import { mapActions } from "vuex";
+
     export default {
 
         data() {
@@ -64,6 +67,15 @@
                     toolName: "Annotation Tool"
                 }
             };
+        },
+
+        created() {
+
+            this.$store.watch(
+                () => { return this.$store.state; },
+                this.updatePageDataAccessibility,
+                { deep: true }
+            );
         },
 
         computed: {
@@ -86,6 +98,11 @@
         },
 
         methods: {
+
+            ...mapActions([
+
+                "updatePageDataAccessibility"
+            ]),
 
             ...mapMutations([
 

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -52,9 +52,6 @@
     // Fields listed in mapState below can be found in the store (index.js)
     import { mapState } from "vuex";
 
-    // Allows for reference to store actions (index.js)
-    import { mapActions } from "vuex";
-
     export default {
 
         data() {

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -24,7 +24,7 @@
                         :active="currentPageName === navItem.fullName"
                         :class="getNavItemColor(navItem)"
                         :data-cy="'menu-item-' + navItem.pageName"
-                        :disabled="!navItem.accessible"
+                        :disabled="!isPageAccessible(navItem.pageName)"
                         :key="navItem.pageName"
                         :to="navItem.location"
                         @click="setCurrentPage(navItem.pageName)">
@@ -69,15 +69,6 @@
             };
         },
 
-        created() {
-
-            this.$store.watch(
-                () => { return this.$store.state; },
-                this.updatePageDataAccessibility,
-                { deep: true }
-            );
-        },
-
         computed: {
 
             ...mapGetters([
@@ -99,11 +90,6 @@
 
         methods: {
 
-            ...mapActions([
-
-                "updatePageDataAccessibility"
-            ]),
-
             ...mapMutations([
 
                 "setCurrentPage"
@@ -119,7 +105,7 @@
                     variant = "dark";
                 }
                 // Else, if the page is accessible
-                else if ( p_navItemData.accessible  ) {
+                else if ( this.isPageAccessible(p_navItemData.pageName) ) {
                     variant = "success";
                 }
 

--- a/store/index.js
+++ b/store/index.js
@@ -5,18 +5,10 @@ export const state = () => ({
 
     categories: {
 
-        "Subject ID": {
-
-        },
-        "Age": {
-
-        },
-        "Sex": {
-
-        },
-        "Diagnosis": {
-
-        }
+        "Subject ID": {},
+        "Age": {},
+        "Sex": {},
+        "Diagnosis": {}
     },
 
     colorInfo: {
@@ -63,20 +55,59 @@ export const state = () => ({
         annotated: {}
     },
 
-    dataTable: []
+    dataTable: [],
+
+    pageData: {
+
+        home: {
+
+            accessible: true,
+            fullName: "Home",
+            location: "/",
+            pageName: "index"
+        },
+
+        categorization: {
+
+            accessible: false,
+            fullName: "Categorization",
+            location: "categorization",
+            pageName: "categorization"
+        },
+
+        annotation: {
+
+            accessible: false,
+            fullName: "Annotation",
+            location: "annotation",
+            pageName: "annotation"
+        },
+
+        download: {
+
+            accessible: false,
+            fullName: "Download",
+            location: "download",
+            pageName: "download"
+        }
+    }
 });
 
 export const getters = {
 
     getCategoryNames (p_state) {
+
         return Object.keys(p_state.categories);
     },
 
     getColumnDescription: (p_state) => (p_columnName) => {
+
         if ( Object.hasOwn(p_state.dataDictionary.annotated[p_columnName], "description") ) {
+
             return p_state.dataDictionary.annotated[p_columnName].description;
         }
         else {
+
             return "";
         }
     },

--- a/store/index.js
+++ b/store/index.js
@@ -61,7 +61,6 @@ export const state = () => ({
 
         home: {
 
-            accessible: true,
             fullName: "Home",
             location: "/",
             pageName: "home"
@@ -69,7 +68,6 @@ export const state = () => ({
 
         categorization: {
 
-            accessible: false,
             fullName: "Categorization",
             location: "categorization",
             pageName: "categorization"
@@ -77,7 +75,6 @@ export const state = () => ({
 
         annotation: {
 
-            accessible: false,
             fullName: "Annotation",
             location: "annotation",
             pageName: "annotation"
@@ -85,7 +82,6 @@ export const state = () => ({
 
         download: {
 
-            accessible: false,
             fullName: "Download",
             location: "download",
             pageName: "download"
@@ -215,19 +211,8 @@ export const actions = {
         commit("setDataTable", data);
         commit("initializeColumnToCategoryMap", getters.getColumnNames);
         commit("initializeDataDictionary");
-    },
-
-    updatePageDataAccessibility({ state, commit, getters }) {
-
-        for ( const pageName in state.pageData ) {
-
-            commit("setPageAccessible", {
-
-                pageName: pageName,
-                accessible: getters.isPageAccessible(pageName)
-            });
-        }
     }
+
 };
 
 export const mutations = {

--- a/store/index.js
+++ b/store/index.js
@@ -64,7 +64,7 @@ export const state = () => ({
             accessible: true,
             fullName: "Home",
             location: "/",
-            pageName: "index"
+            pageName: "home"
         },
 
         categorization: {
@@ -212,6 +212,18 @@ export const actions = {
         commit("setDataTable", data);
         commit("initializeColumnToCategoryMap", getters.getColumnNames);
         commit("initializeDataDictionary");
+    },
+
+    updatePageDataAccessibility({ state, commit, getters }) {
+
+        for ( const pageName in state.pageData ) {
+
+            commit("setPageAccessible", {
+
+                pageName: pageName,
+                accessible: getters.isPageAccessible(pageName)
+            });
+        }
     }
 };
 
@@ -310,5 +322,10 @@ export const mutations = {
         }
 
         p_state.dataTable = dataTable;
+    },
+
+    setPageAccessible(p_state, p_payload) {
+
+        p_state.pageData[p_payload.pageName].accessible = p_payload.accessible;
     }
 };


### PR DESCRIPTION
Closes #315 and #317

Some agent in the tool must be responsible for indicating that a page is accessible to the user (on the page via user action, or at some higher level like the navbar or layout, etc.) Previously, actions on a page by a user would manually change the accessibility status of the next page (via an action call to change `pageData.<pageName>.accessible`).

The navbar now keeps a watch on the store for changes, updating the accessible status of pages via `updatePageDataAccessibility` as the relevant changes are made to the store that would unlock them. This has the side effect of also keeping the next page button status on each page up to date with the state of the store.

The more complex Vuex getter `isPageAccessible` could not be reactive because it currently returns a boolean. [Vue recalculates computed values based on whether or not values used in the computed function to create the return value have changed.](https://learnvue.co/tutorials/computed-properties-guide#the-basics-of-vue-reactivity). In the case of a primitive like a boolean with one return statement, `isPageAccessible` would only be calculated once. However, page accessibility state depends on multiple variables in the store depending on which page is being checked as accessible. Even a re-implementation of the function with multiple return statements does not produce the desired reactivity.

There are at least two methods for making sure that store changes trigger a check for page accessibility. The agent (in this case the `tool-navbar` component) can either place a watch on the specific store variables that may be involved in a state change OR it may deeply watch `$store.state` itself. (Suggestion for solution found [here](https://stackoverflow.com/questions/46096261/how-can-i-watch-synchronously-a-state-change-in-vuex).)

This is accomplished via the placement of a watch in the `created` hook:

```
        created() {

            this.$store.watch(
                () => { return this.$store.state; },
                this.updatePageDataAccessibility,
                { deep: true }
            );
        },
```

The latter is the one implemented with this PR. A change in `$store.state` triggers a call to new store action `updatePageDataAccessibility`. The `disabled` attribute in the navbar and next page button are then simply tied to the `pageData.<pageName>.accessible` field which will always reflect the current state of the store.



