### PR TITLE
Updates to Index page for data table + data dictionary for store refactor

### DIFF
--- a/components/file-selector.vue
+++ b/components/file-selector.vue
@@ -4,9 +4,9 @@
 
         <b-row class="file-selector-row">
             <b-form>
-                <label class="file-selector-button btn">
+                <label :class="labelClass" :disabled="!enabled">
                     {{ uiText.instructions }}
-                    <input type="file" :accept="contentType" @change="onFileSelected" />
+                    <input v-if="enabled" type="file" :accept="contentType" @change="onFileSelected" />
                 </label>
                 <span>{{ fileName }}</span>
             </b-form>
@@ -24,7 +24,8 @@
 
         props: {
 
-            contentType: { type: String, required: true }
+            contentType: { type: String, required: true },
+            enabled: { type: Boolean, required: true }
         },
 
         data() {
@@ -52,6 +53,12 @@
 
                 // null - No file has been selected yet
                 return ( null === this.fileInput ) ? "" : this.fileInput.name;
+            },
+
+            labelClass() {
+
+                return ( this.enabled ) ? "file-selector-button btn" :
+                    "disabled-file-selector-button btn";
             }
         },
 
@@ -128,12 +135,14 @@
         display: none;
     }
 
-    .custom-file-upload {
+    .disabled-file-selector-button {
 
-        border: 1px solid #ccc;
-        cursor: pointer;
-        display: inline-block;
-        padding: 6px 12px;
+        background-color: #6c757d;
+        border-color: #6c757d;
+        border-radius: 5px;
+        color: white;
+        opacity: 0.65;
+        padding: 0.5em 0.75em 0.5em 0.75em;
     }
 
     .file-selector-button {

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -24,7 +24,7 @@
                         :active="currentPageName === navItem.fullName"
                         :class="getNavItemColor(navItem)"
                         :data-cy="'menu-item-' + navItem.pageName"
-                        :disabled="!isPageAccessible(pageData[getNextPage].pageName)"
+                        :disabled="!isPageAccessible(navItem.pageName)"
                         :key="navItem.pageName"
                         :to="navItem.location"
                         @click="setCurrentPage(navItem.pageName)">

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -70,6 +70,7 @@
 
             ...mapGetters([
 
+                "getNextPage",
                 "isPageAccessible"
             ]),
 

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -70,7 +70,6 @@
 
             ...mapGetters([
 
-                "getNextPage",
                 "isPageAccessible"
             ]),
 

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -24,7 +24,7 @@
                         :active="currentPageName === navItem.fullName"
                         :class="getNavItemColor(navItem)"
                         :data-cy="'menu-item-' + navItem.pageName"
-                        :disabled="!isPageAccessible(navItem.pageName)"
+                        :disabled="!navItem.accessible"
                         :key="navItem.pageName"
                         :to="navItem.location"
                         @click="setCurrentPage(navItem.pageName)">
@@ -52,6 +52,9 @@
     // Fields listed in mapState below can be found in the store (index.js)
     import { mapState } from "vuex";
 
+    // Allows for reference to store actions (index.js)
+    import { mapActions } from "vuex";
+
     export default {
 
         data() {
@@ -64,6 +67,15 @@
                     toolName: "Annotation Tool"
                 }
             };
+        },
+
+        created() {
+
+            this.$store.watch(
+                () => { return this.$store.state; },
+                this.updatePageDataAccessibility,
+                { deep: true }
+            );
         },
 
         computed: {
@@ -86,6 +98,11 @@
         },
 
         methods: {
+
+            ...mapActions([
+
+                "updatePageDataAccessibility"
+            ]),
 
             ...mapMutations([
 

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -24,7 +24,7 @@
                         :active="currentPageName === navItem.fullName"
                         :class="getNavItemColor(navItem)"
                         :data-cy="'menu-item-' + navItem.pageName"
-                        :disabled="!navItem.accessible"
+                        :disabled="!isPageAccessible(pageData[getNextPage].pageName)"
                         :key="navItem.pageName"
                         :to="navItem.location"
                         @click="setCurrentPage(navItem.pageName)">
@@ -52,9 +52,6 @@
     // Fields listed in mapState below can be found in the store (index.js)
     import { mapState } from "vuex";
 
-    // Allows for reference to store actions (index.js)
-    import { mapActions } from "vuex";
-
     export default {
 
         data() {
@@ -67,15 +64,6 @@
                     toolName: "Annotation Tool"
                 }
             };
-        },
-
-        created() {
-
-            this.$store.watch(
-                () => { return this.$store.state; },
-                this.updatePageDataAccessibility,
-                { deep: true }
-            );
         },
 
         computed: {
@@ -98,11 +86,6 @@
         },
 
         methods: {
-
-            ...mapActions([
-
-                "updatePageDataAccessibility"
-            ]),
 
             ...mapMutations([
 

--- a/cypress/component/index_page.cy.js
+++ b/cypress/component/index_page.cy.js
@@ -1,132 +1,140 @@
-import indexPage from "~/pages/index.vue";
 import fileSelector from "~/components/file-selector.vue";
-
+import indexPage from "~/pages/index.vue";
 
 let store = {};
 
 const stubs = {
+
     "file-selector": fileSelector
 };
 
 describe("The index page", () => {
-    beforeEach(() => {
-        store = {
-            dispatch: () => {},
-            getters: {
-                getColumnNames: () => [
-                        "col1",
-                        "col2"
-                    ]
-            },
-            state: {
-                dataTable: [
-                    {"col1": "val1", "col2": "val2"},
-                    {"col1": "val11", "col2": "val22"}
-                ],
-                dataDictionary: {
-                    "col1": "something",
-                    "col2": "other"
-                }
 
+    // Setup
+    beforeEach(() => {
+
+        store = {
+
+            dispatch: () => {},
+            state: {
+
+                dataDictionary: { userProvided: {}, annotated: {} },
+                dataTable: []
             }
         };
-
     });
 
-    it("mounts empty and displays all UI elements", () => {
+    it("Mounts empty and displays all UI elements", () => {
+
+        // Act
         cy.mount(indexPage, {
-            mocks: {
-                $store: Object.assign(store, {
-                    getters: store.getters,
-                    state: {
-                        dataTable: [],
-                        dataDictionary: {}
-                    }
-                })
-            },
-            computed: store.getters,
+
+            mocks: { $store: store },
             stubs: stubs,
             plugins: ["bootstrap-vue"]
         });
+
+        // Assert
         cy.get("[data-cy='data-table-display']").should("be.visible.and.empty");
         cy.get("[data-cy='data-table-selector']").should("be.visible").contains("Choose file");
         cy.get("[data-cy='data-dictionary-display']").should("be.visible.and.empty");
         cy.get("[data-cy='data-dictionary-selector']").should("be.visible").contains("Choose file");
-
-        }
-    );
-    it("correctly displays previews of the loaded data", () => {
-        cy.mount(indexPage, {
-            mocks: {
-                $store: store
-            },
-            computed: store.getters,
-            stubs: stubs,
-            plugins: ["bootstrap-vue"]
-        });
-        // Because we're looking at an input field, we need to assert over the value and
-        // can't just use .contains as usual
-        cy.get("[data-cy='data-table-display']").should('include.value', 'val1\tval2');
-        cy.get("[data-cy='data-dictionary-display']").should('include.value', '"col1": "something"');
-
     });
 
-    it("dispatches an action when a dataTable is loaded", () => {
-        store.state.dataTable = [];
-        cy.fixture("examples/good/example_short.tsv").as("exampleTable");
-        cy.spy(store, 'dispatch').as('dispatchSpy');
+    it("Correctly displays previews of the loaded data", () => {
+
+        // Act
         cy.mount(indexPage, {
-            mocks: {
-                $store: store
-            },
-            computed: store.getters,
+
+            mocks: { $store: Object.assign({}, store, {
+
+                getters: { getColumnNames: () => ["col1", "col2"] },
+                state: {
+
+                    dataTable: [
+
+                        {"col1": "val1", "col2": "val2"},
+                        {"col1": "val11", "col2": "val22"}
+                    ],
+                    dataDictionary: {
+
+                        userProvided: {
+
+                            "col1": "something",
+                            "col2": "other"
+                        },
+
+                        annotated: {
+
+                            "col1": "something",
+                            "col2": "other"
+                        }
+                    }
+                }
+            })},
+            computed: { getColumnNames: () => ["col1", "col2"] },
             stubs: stubs,
             plugins: ["bootstrap-vue"]
         });
+
+        // Assert - Because we're looking at an input field, we need to assert
+        // over the value and can't just use .contains as usual
+        cy.get("[data-cy='data-table-display']").should('include.value', 'val1\tval2');
+        cy.get("[data-cy='data-dictionary-display']").should('include.value', '"col1": "something"');
+    });
+
+    it("Dispatches an action when a dataTable is loaded", () => {
+
+        // Setup
+        cy.fixture("examples/good/example_short.tsv").as("exampleTable");
+        cy.spy(store, "dispatch").as("dispatchSpy");
+        cy.mount(indexPage, {
+
+            mocks: { $store: store },
+            stubs: stubs,
+            plugins: ["bootstrap-vue"]
+        });
+
+        // Act
         cy.get("[data-cy='data-table-selector']").contains("Choose file").click().selectFile("@exampleTable");
+
+        // Assert
         cy.get("@dispatchSpy").should("have.been.calledWith", "processDataTable", {
             "data": [
-                [
-                    "participant_id",
-                    "age",
-                    "sex"
-                ],
-                [
-                    "sub-1",
-                    "026Y",
-                    "1"
-                ],
-                [
-                    "sub-2",
-                    "024Y",
-                    "2"
-                ]
+                [ "participant_id", "age", "sex" ],
+                [ "sub-1", "026Y", "1" ],
+                [ "sub-2", "024Y", "2" ]
             ],
             "filename": "example_short.tsv"
         });
         cy.get("[data-cy='data-table-selector']").contains("example_short.tsv");
     });
 
-    it("dispatches an action when a dataDictionary is loaded", () => {
+    it("Dispatches an action when a dataDictionary is loaded", () => {
 
-        store.state.dataDictionary = {};
+        // Setup
+        store.state.dataTable = [
+            [ "participant_id", "age", "sex" ],
+            [ "sub-1", "026Y", "1" ],
+            [ "sub-2", "024Y", "2" ]
+        ];
         cy.fixture("examples/good/example_short.json").as("exampleDictionary");
         cy.spy(store, "dispatch").as("dispatchSpy");
         cy.mount(indexPage, {
-            mocks: {
-                $store: store
-            },
-            computed: store.getters,
+
+            mocks: { $store: store },
             stubs: stubs,
             plugins: ["bootstrap-vue"]
         });
 
+        // Act
         cy.get("[data-cy='data-dictionary-selector']").contains("Choose file").click().selectFile("@exampleDictionary");
+
+        // Assert
         cy.get("@dispatchSpy").should("have.been.calledWith", "processDataDictionary", {
             "data": "{\"age\":{\"Description\":\"age of the participant\",\"Units\":\"years\"},\"sex\":{\"Description\":\"sex of the participant as reported by the participant\",\"Levels\":{\"M\":\"male\",\"F\":\"female\"}},\"group\":{\"Description\":\"diagnostic status determined by the study clinician at baseline\",\"Levels\":{\"AD\":\"individuals with Alzheimer's Disease\",\"HC\":\"healthy controls\",\"MCI\":\"individuals with Mild Cognitive Impairment\"}}}",
             "filename": "example_short.json"
         });
-
         cy.get("[data-cy='data-dictionary-selector']").contains("example_short.json");
     });
 });

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -36,7 +36,7 @@
             <textarea
                 :cols="textArea.height"
                 :rows="textArea.width"
-                :value="dataDictionaryAsString"
+                :value="stringifiedDataDictionary"
                 data-cy="data-dictionary-display" />
         </b-row>
 
@@ -71,8 +71,6 @@
                     dataTable: "text/tab-separated-values"
                 },
 
-                dataDictionaryAsString: "",
-
                 // Size of the file display textboxes
                 textArea: {
 
@@ -89,11 +87,6 @@
             };
         },
 
-        mounted() {
-
-            this.stringifyDataDictionary();
-        },
-
         computed: {
 
             ...mapState([
@@ -107,6 +100,12 @@
                 return ( this.dataTable.length > 0 );
             },
 
+            stringifiedDataDictionary() {
+
+                return ( 0 === Object.keys(this.dataDictionary.userProvided).length )
+                    ? "" : JSON.stringify(this.dataDictionary.userProvided, null, 4);
+            },
+
             stringifiedDataTable() {
 
                 // Returns only the cell values of the table as a formatted string (no column names)
@@ -116,34 +115,13 @@
             }
         },
 
-        watch: {
-
-            dataDictionary: {
-
-                deep: true,
-                handler() {
-
-                    this.stringifyDataDictionary();
-                }
-            }
-        },
-
         methods: {
 
             ...mapActions([
 
                 "processDataDictionary",
                 "processDataTable"
-            ]),
-
-            stringifyDataDictionary() {
-
-                this.dataDictionaryAsString = "";
-                if ( Object.keys(this.dataDictionary.userProvided).length > 0 ) {
-
-                    this.dataDictionaryAsString = JSON.stringify(this.dataDictionary.userProvided, null, 4);
-                }
-            }
+            ])
         }
     };
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -95,7 +95,8 @@
 
             stringifiedDataDictionary() {
 
-                return JSON.stringify(this.dataDictionary, null, 4);
+                return ( 0 === Object.keys(this.dataDictionary.userProvided).length ) ? "" :
+                    JSON.stringify(this.dataDictionary.userProvided, null, 4);
             },
 
             stringifiedDataTable() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -97,6 +97,8 @@
 
             dataTableSelected() {
 
+                // Return whether or not a data table has been selected
+                // (used to enable data dictionary selection)
                 return ( this.dataTable.length > 0 );
             },
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -21,7 +21,8 @@
             <file-selector
                 data-cy="data-table-selector"
                 :content-type="contentTypes.dataTable"
-                @file-selected="processDataTable($event)" />
+                @file-selected="processDataTable($event)"
+                :enabled="true" />
         </b-row>
 
 
@@ -44,7 +45,8 @@
             <file-selector
                 data-cy="data-dictionary-selector"
                 :content-type="contentTypes.dataDictionary"
-                @file-selected="processDataDictionary($event)" />
+                @file-selected="processDataDictionary($event)"
+                :enabled="dataTableSelected" />
         </b-row>
 
     </b-container>
@@ -92,6 +94,11 @@
                 "dataDictionary",
                 "dataTable"
             ]),
+
+            dataTableSelected() {
+
+                return ( this.dataTable.length > 0 );
+            },
 
             stringifiedDataDictionary() {
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,7 +12,7 @@
             <textarea
                 :cols="textArea.height"
                 :rows="textArea.width"
-                v-model="stringifiedDataTable"
+                :value="stringifiedDataTable"
                 data-cy="data-table-display" />
         </b-row>
 
@@ -36,7 +36,7 @@
             <textarea
                 :cols="textArea.height"
                 :rows="textArea.width"
-                v-model="stringifiedDataDictionary"
+                :value="dataDictionaryAsString"
                 data-cy="data-dictionary-display" />
         </b-row>
 
@@ -71,6 +71,8 @@
                     dataTable: "text/tab-separated-values"
                 },
 
+                dataDictionaryAsString: "",
+
                 // Size of the file display textboxes
                 textArea: {
 
@@ -87,6 +89,11 @@
             };
         },
 
+        mounted() {
+
+            this.stringifyDataDictionary();
+        },
+
         computed: {
 
             ...mapState([
@@ -100,12 +107,6 @@
                 return ( this.dataTable.length > 0 );
             },
 
-            stringifiedDataDictionary() {
-
-                return ( 0 === Object.keys(this.dataDictionary.userProvided).length ) ? "" :
-                    JSON.stringify(this.dataDictionary.userProvided, null, 4);
-            },
-
             stringifiedDataTable() {
 
                 // Returns only the cell values of the table as a formatted string (no column names)
@@ -115,13 +116,34 @@
             }
         },
 
+        watch: {
+
+            dataDictionary: {
+
+                deep: true,
+                handler() {
+
+                    this.stringifyDataDictionary();
+                }
+            }
+        },
+
         methods: {
 
             ...mapActions([
 
                 "processDataDictionary",
                 "processDataTable"
-            ])
+            ]),
+
+            stringifyDataDictionary() {
+
+                this.dataDictionaryAsString = "";
+                if ( Object.keys(this.dataDictionary.userProvided).length > 0 ) {
+
+                    this.dataDictionaryAsString = JSON.stringify(this.dataDictionary.userProvided, null, 4);
+                }
+            }
         }
     };
 

--- a/store/index.js
+++ b/store/index.js
@@ -280,6 +280,10 @@ export const mutations = {
                               p_state.dataDictionary.annotated[column],
                               newDataDictionary[column]);
         }
+
+        // 2. Create a new object in case additions/deletions to the data
+        // dictionary object in order to maintain Vue reactivity
+        p_state.dataDictionary = Object.assign({}, p_state.dataDictionary);
     },
 
     setDataTable(p_state, p_dataTable) {

--- a/store/index.js
+++ b/store/index.js
@@ -5,18 +5,10 @@ export const state = () => ({
 
     categories: {
 
-        "Subject ID": {
-
-        },
-        "Age": {
-
-        },
-        "Sex": {
-
-        },
-        "Diagnosis": {
-
-        }
+        "Subject ID": {},
+        "Age": {},
+        "Sex": {},
+        "Diagnosis": {}
     },
 
     colorInfo: {
@@ -63,20 +55,59 @@ export const state = () => ({
         annotated: {}
     },
 
-    dataTable: []
+    dataTable: [],
+
+    pageData: {
+
+        home: {
+
+            accessible: true,
+            fullName: "Home",
+            location: "/",
+            pageName: "index"
+        },
+
+        categorization: {
+
+            accessible: false,
+            fullName: "Categorization",
+            location: "categorization",
+            pageName: "categorization"
+        },
+
+        annotation: {
+
+            accessible: false,
+            fullName: "Annotation",
+            location: "annotation",
+            pageName: "annotation"
+        },
+
+        download: {
+
+            accessible: false,
+            fullName: "Download",
+            location: "download",
+            pageName: "download"
+        }
+    }
 });
 
 export const getters = {
 
     getCategoryNames (p_state) {
+
         return Object.keys(p_state.categories);
     },
 
     getColumnDescription: (p_state) => (p_columnName) => {
+
         if ( Object.hasOwn(p_state.dataDictionary.annotated[p_columnName], "description") ) {
+
             return p_state.dataDictionary.annotated[p_columnName].description;
         }
         else {
+
             return "";
         }
     },

--- a/store/index.js
+++ b/store/index.js
@@ -64,7 +64,7 @@ export const state = () => ({
             accessible: true,
             fullName: "Home",
             location: "/",
-            pageName: "index"
+            pageName: "home"
         },
 
         categorization: {
@@ -212,6 +212,18 @@ export const actions = {
         commit("setDataTable", data);
         commit("initializeColumnToCategoryMap", getters.getColumnNames);
         commit("initializeDataDictionary");
+    },
+
+    updatePageDataAccessibility({ state, commit, getters }) {
+
+        for ( const pageName in state.pageData ) {
+
+            commit("setPageAccessible", {
+
+                pageName: pageName,
+                accessible: getters.isPageAccessible(pageName)
+            });
+        }
     }
 };
 
@@ -310,5 +322,10 @@ export const mutations = {
         }
 
         p_state.dataTable = dataTable;
+    },
+
+    setPageAccessible(p_state, p_payload) {
+
+        p_state.pageData[p_payload.pageName].accessible = p_payload.accessible;
     }
 };


### PR DESCRIPTION
This closes #314 and #320 

Several updates here are made for the index page relating to the recent store refactor.

1. The workflow for the user has changed in that they are no longer able to select a data dictionary without first having selected a data table. This has been accomplished by adding a new feature to `file-selector` care of the prop `enabled`. File selection for a data dictionary is disabled until a data table has been selected. 
2. `textarea` elements on the index page have been converted to one way binding (user input does not edit underlying value) via the `value` attribute instead of the two-way bind via `v-model`
3. Reactivity for the textarea for the data dictionary input has been fixed by reassigning the data dictionary to itself in the store's `setDataTable` mutation once any new keys and values have been added or removed from the current existing dictionary.