### PR TITLE
Build static

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ $ npm run generate
 
 For detailed explanation on how things work, check out the [documentation](https://nuxtjs.org).
 
+## Deployment
+
+To deploy the static build on GH pages, run
+
+```bash
+npm run generate
+npm run deploy
+```
+
+See the [Nuxt documention](https://nuxtjs.org/deployments/github-pages/) for more details.
+
 ## Special Directories
 
 You can create the following extra directories, some of which have special behaviors. Only `pages` is required; you can delete them if you don't want to use their functionality.

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -60,5 +60,9 @@ export default {
 		}
 	},
 
-	devtool: "source-map"
+	devtool: "source-map",
+	target: "static",
+	router: {
+		base: "/annotation-tool/"
+	}
 };

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -61,8 +61,5 @@ export default {
 	},
 
 	devtool: "source-map",
-	target: "static",
-	router: {
-		base: "/annotation-tool/"
-	}
+	target: "static"
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "eslint-plugin-cypress": "^2.12.1",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-vue": "^8.5.0",
-        "husky": "^7.0.4"
+        "husky": "^7.0.4",
+        "push-dir": "^0.4.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -11996,6 +11997,21 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/push-dir": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/push-dir/-/push-dir-0.4.1.tgz",
+      "integrity": "sha512-Nrrsly0c3kCfu725Jnif/s5adHpBwKCGWBttHVxTndF4iyGBSFtNi/pduFxHF5ks0kWtHcbA3XXP5MEra6iiCA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "push-dir": "bin/push-dir.js"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/q": {
@@ -25221,6 +25237,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "push-dir": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/push-dir/-/push-dir-0.4.1.tgz",
+      "integrity": "sha512-Nrrsly0c3kCfu725Jnif/s5adHpBwKCGWBttHVxTndF4iyGBSFtNi/pduFxHF5ks0kWtHcbA3XXP5MEra6iiCA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
     },
     "q": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "npx eslint --ext .vue  --ext .js .",
     "prepare": "husky install",
     "heroku-postbuild": "npm run build",
-    "cypress:open": "cypress open"
+    "cypress:open": "cypress open",
+    "deploy": "push-dir --dir=dist --branch=gh-pages --cleanup"
   },
   "dependencies": {
     "@nuxtjs/axios": "^5.13.6",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-vue": "^8.5.0",
-    "husky": "^7.0.4"
+    "husky": "^7.0.4",
+    "push-dir": "^0.4.1"
   }
 }

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -17,7 +17,7 @@
             I forced this block to be rendered client-side only for now and that fixed it for now
             See: https://nuxtjs.org/docs/features/nuxt-components/#the-client-only-component
         -->
-        <client-only>
+        <!-- <client-only> -->
             <!-- This gives us built-in keyboard navigation! -->
             <b-tabs
                 data-cy="annotation-category-tabs"
@@ -47,7 +47,7 @@
                 </b-tab>
 
             </b-tabs>
-        </client-only>
+        <!-- </client-only> -->
 
         <b-row>
 


### PR DESCRIPTION
This PR sets up the master branch for deployment on GH pages and to use a custom domain https://annotate.neurobagel.org

Most steps are just direct from the docs: https://nuxtjs.org/deployments/github-pages/

I did some extra things:
- removed the client-only / no-ssr tag on the annotation.vue page (not compatible with static build)
- removed the custom route prefix that is suggested for GH deployments in the docs because we are using a custom domain