### PR TITLE
New mutation setHeuristic for phase 2 store refactor

### DIFF
--- a/components/annot-continuous-values.vue
+++ b/components/annot-continuous-values.vue
@@ -10,7 +10,7 @@
                 data-cy="selectTransform"
                 :options="transformChoices"
                 :value="getActiveHeuristic(this.activeCategory)"
-                @input="dispatchHeuristic($event)" />
+                @input="commitHeuristic($event)" />
 
             <b-table
                 hover
@@ -26,7 +26,8 @@
 </template>
 
 <script>
-    import {mapActions, mapGetters} from "vuex";
+
+    import { mapGetters, mapMutations } from "vuex";
 
     export default {
 
@@ -49,16 +50,22 @@
             };
         },
         computed: {
+
             ...mapGetters([
+
                 "getPreviewValues",
                 "getHarmonizedPreview",
                 "getTransformHeuristics",
                 "getActiveHeuristic"
             ]),
+
             transformChoices() {
+
                 return this.getTransformHeuristics(this.activeCategory);
             },
+
             validationItems() {
+
                 // A table generated from the unique values provided by the
                 // store for columns assigned to the activeCategory.
                 return Object.entries(
@@ -74,12 +81,17 @@
                 }).flat();
             }
         },
+
         methods: {
-            ...mapActions([
+
+            ...mapMutations([
+
                 "setHeuristic"
             ]),
-            dispatchHeuristic(heuristic) {
-                this.setHeuristic(this.activeCategory, heuristic);
+
+            commitHeuristic(p_heuristic) {
+
+                this.setHeuristic({ column: this.activeCategory, heuristic: p_heuristic });
             }
         }
     };

--- a/components/annot-continuous-values.vue
+++ b/components/annot-continuous-values.vue
@@ -91,6 +91,9 @@
 
             commitHeuristic(p_heuristic) {
 
+                // TODO: With the addition of ability to set heuristic for
+                // individual columns, 'activeCategory' below will be replaced
+                // with the appropriate column name
                 this.setHeuristic({ column: this.activeCategory, heuristic: p_heuristic });
             }
         }

--- a/cypress/component/annot-continuous-values.cy.js
+++ b/cypress/component/annot-continuous-values.cy.js
@@ -19,65 +19,75 @@ const store = {
 
 
 const props = {
+
     activeCategory: "category1"
 };
 
 describe("continuous-values-component", () => {
-        it("correctly displays preview values provided by the store", () => {
-                cy.mount(annotContinuousValues, {
-                    propsData: props,
-                    computed: store.getters,
-                    plugins: ["vue-select"]
-                });
-                cy.get("[data-cy='dataTable']").then(table => {
-                    // TODO: find a pattern to iterate over the values directly
-                    expect(table).to.contain("1Y");
-                    expect(table).to.contain("11Y");
-                    expect(table).to.contain("2,1");
-                    expect(table).to.contain("22,1");
-                });
-            }
-        );
 
-        it("can select a transformation and then dispatches it to the store", () => {
-                const mockStore = {
-                    dispatch: () => {
-                    }
-                };
-                cy.spy(mockStore, 'dispatch').as('dispatchSpy');
+    it("Correctly displays preview values provided by the store", () => {
 
-                cy.mount(annotContinuousValues, {
-                    propsData: props,
-                    computed: store.getters,
-                    mocks: {
-                        $store: mockStore
-                    },
-                    plugins: ["vue-select"]
-                });
-                cy.get("[data-cy='selectTransform']").click();
-                cy.get("[data-cy='selectTransform']").find("li").contains('float').click();
-                cy.get("@dispatchSpy").should('have.been.calledWith', "setHeuristic", "category1", "float");
-            }
-        );
+        cy.mount(annotContinuousValues, {
+            propsData: props,
+            computed: store.getters,
+            plugins: ["vue-select"]
+        });
 
-        it("applies a selected heuristic and previews transformed values", () => {
-                cy.mount(annotContinuousValues, {
-                        propsData: props,
-                        computed: Object.assign(store.getters, {
-                            getActiveHeuristic: () => (activeCategory) => "float",
-                            getHarmonizedPreview: () => (column, missingValue) => column + "-" + missingValue + "-harmonized"
-                        })
-                    }
-                );
-            cy.get("[data-cy='selectTransform']").contains("float");
-            cy.get("[data-cy='dataTable']").then(table => {
-                // TODO: find a pattern to iterate over the values directly
-                expect(table).to.contain("column1-1Y-harmonized");
-                expect(table).to.contain("column1-11Y-harmonized");
-                expect(table).to.contain("column2-2,1-harmonized");
-                expect(table).to.contain("column2-22,1-harmonized");
-            });
+        cy.get("[data-cy='dataTable']").then(table => {
+            // TODO: find a pattern to iterate over the values directly
+            expect(table).to.contain("1Y");
+            expect(table).to.contain("11Y");
+            expect(table).to.contain("2,1");
+            expect(table).to.contain("22,1");
+        });
+    });
+
+    it("Can select a transformation and then dispatches it to the store", () => {
+
+        const mockStore = {
+
+            commit: () => {},
+            mutations: {
+
+                setHeuristic: () => (p_state, { column, heuristic }) => {},
+                designateAsMissing: () => (columnName, rawValue) => {}
             }
-        );
-    }
-);
+        };
+        cy.spy(mockStore, "commit").as("commitSpy");
+
+        cy.mount(annotContinuousValues, {
+
+            propsData: props,
+            computed: store.getters,
+            mocks: { $store: mockStore },
+            plugins: ["vue-select"]
+        });
+
+        cy.get("[data-cy='selectTransform']").click();
+        cy.get("[data-cy='selectTransform']")
+            .find("li")
+            .contains("float")
+            .click();
+        cy.get("@commitSpy").should('have.been.calledWith', "setHeuristic", { column: "category1", heuristic: "float" });
+    });
+
+    it("Applies a selected heuristic and previews transformed values", () => {
+
+        cy.mount(annotContinuousValues, {
+            propsData: props,
+            computed: Object.assign(store.getters, {
+                getActiveHeuristic: () => (activeCategory) => "float",
+                getHarmonizedPreview: () => (column, missingValue) => column + "-" + missingValue + "-harmonized"
+            })
+        });
+
+        cy.get("[data-cy='selectTransform']").contains("float");
+        cy.get("[data-cy='dataTable']").then(table => {
+            // TODO: find a pattern to iterate over the values directly
+            expect(table).to.contain("column1-1Y-harmonized");
+            expect(table).to.contain("column1-11Y-harmonized");
+            expect(table).to.contain("column2-2,1-harmonized");
+            expect(table).to.contain("column2-22,1-harmonized");
+        });
+    });
+});

--- a/cypress/component/annot-continuous-values.cy.js
+++ b/cypress/component/annot-continuous-values.cy.js
@@ -2,8 +2,12 @@ import annotContinuousValues from "~/components/annot-continuous-values";
 
 
 const store = {
+
+    commit: () => {},
+
     getters: {
-        getActiveHeuristic: () => (activeCategory) => null,
+
+        getActiveHeuristic: () => (column) => null,
         getHarmonizedPreview: () => (column, missingValue) => null,
         getPreviewValues: () => (activeCategory) => {
             return {
@@ -14,13 +18,20 @@ const store = {
         getTransformHeuristics: () => (activeCategory) => {
             return ["float", "bounded", "euro", "range", "int", "string", "isoyear"];
         }
+    },
+
+    mutations: {
+
+        setHeuristic: () => (p_state, { column, heuristic }) => {},
+        designateAsMissing: () => (columnName, rawValue) => {}
     }
 };
 
 
 const props = {
 
-    activeCategory: "category1"
+    // TODO: This prop is currently necessary until new column-based heuristic feature is added
+    activeCategory: "column1"
 };
 
 describe("continuous-values-component", () => {
@@ -44,22 +55,13 @@ describe("continuous-values-component", () => {
 
     it("Can select a transformation and then dispatches it to the store", () => {
 
-        const mockStore = {
-
-            commit: () => {},
-            mutations: {
-
-                setHeuristic: () => (p_state, { column, heuristic }) => {},
-                designateAsMissing: () => (columnName, rawValue) => {}
-            }
-        };
-        cy.spy(mockStore, "commit").as("commitSpy");
+        cy.spy(store, "commit").as("commitSpy");
 
         cy.mount(annotContinuousValues, {
 
             propsData: props,
             computed: store.getters,
-            mocks: { $store: mockStore },
+            mocks: { $store: store },
             plugins: ["vue-select"]
         });
 
@@ -68,7 +70,7 @@ describe("continuous-values-component", () => {
             .find("li")
             .contains("float")
             .click();
-        cy.get("@commitSpy").should('have.been.calledWith', "setHeuristic", { column: "category1", heuristic: "float" });
+        cy.get("@commitSpy").should('have.been.calledWith', "setHeuristic", { column: "column1", heuristic: "float" });
     });
 
     it("Applies a selected heuristic and previews transformed values", () => {
@@ -76,7 +78,7 @@ describe("continuous-values-component", () => {
         cy.mount(annotContinuousValues, {
             propsData: props,
             computed: Object.assign(store.getters, {
-                getActiveHeuristic: () => (activeCategory) => "float",
+                getActiveHeuristic: () => (column) => "float",
                 getHarmonizedPreview: () => (column, missingValue) => column + "-" + missingValue + "-harmonized"
             })
         });

--- a/cypress/unit/store-mutation-setHeuristic.cy.js
+++ b/cypress/unit/store-mutation-setHeuristic.cy.js
@@ -11,13 +11,28 @@ describe("setHeuristic", () => {
 
             dataDictionary: {
                 annotated: {
-                    column1: { transformationHeuristic: "" }
+                    column1: {}
                 }
             }
         };
     });
 
-    it("Set the transformation heuristic of a column", () => {
+    it("Set the heuristic of a column with no transformationHeuristic key", () => {
+
+        // Act
+        mutations.setHeuristic(state, {
+            column: "column1",
+            heuristic: "column1Heuristic"
+        });
+
+        // Assert
+        expect(state.dataDictionary.annotated.column1.transformationHeuristic).to.equal("column1Heuristic");
+    });
+
+    it("Set the heuristic of a column that already has a transformationHeuristic key", () => {
+
+        // Setup
+        state.dataDictionary.annotated.column1.transformationHeuristic = "oldHeuristic";
 
         // Act
         mutations.setHeuristic(state, {

--- a/cypress/unit/store-mutation-setHeuristic.cy.js
+++ b/cypress/unit/store-mutation-setHeuristic.cy.js
@@ -1,0 +1,31 @@
+import { mutations } from "~/store";
+
+let state = {};
+
+describe("setHeuristic", () => {
+
+    beforeEach(() => {
+
+        // Setup
+        state = {
+
+            dataDictionary: {
+                annotated: {
+                    column1: { transformationHeuristic: "" }
+                }
+            }
+        };
+    });
+
+    it("Set the transformation heuristic of a column", () => {
+
+        // Act
+        mutations.setHeuristic(state, {
+            column: "column1",
+            heuristic: "column1Heuristic"
+        });
+
+        // Assert
+        expect(state.dataDictionary.annotated.column1.transformationHeuristic).to.equal("column1Heuristic");
+    });
+});

--- a/cypress/unit/store-mutation-setHeuristic.cy.js
+++ b/cypress/unit/store-mutation-setHeuristic.cy.js
@@ -26,6 +26,7 @@ describe("setHeuristic", () => {
         });
 
         // Assert
+        expect(state.dataDictionary.annotated.column1.transformationHeuristic).to.exist;
         expect(state.dataDictionary.annotated.column1.transformationHeuristic).to.equal("column1Heuristic");
     });
 

--- a/store/index.js
+++ b/store/index.js
@@ -313,5 +313,11 @@ export const mutations = {
         }
 
         p_state.dataTable = dataTable;
+    },
+
+    setHeuristic(p_state, { column, heuristic }) {
+
+        // Set a new transformation heuristic for this column
+        Vue.set(p_state.dataDictionary.annotated[column], "transformationHeuristic", heuristic);
     }
 };


### PR DESCRIPTION
This PR addresses #270.

1. `setHeuristic` is now a mutation that takes a column and heuristic name and assigns the heuristic to the `transformationHeuristic` field in the data dictionary object for that column
2. A unit test has been created for the new `setHeuristic` mutation.
3. The `annot-continuous-values` component has been amended to understand `setHeuristic` as a mutation instead of an action.