### PR TITLE
New 'getHeuristic' getter for phase 2 store refactor

### DIFF
--- a/components/annot-continuous-values.vue
+++ b/components/annot-continuous-values.vue
@@ -9,7 +9,7 @@
             <v-select
                 data-cy="selectTransform"
                 :options="transformChoices"
-                :value="getActiveHeuristic(this.activeCategory)"
+                :value="getHeuristic(this.activeCategory)"
                 @input="commitHeuristic($event)" />
 
             <b-table
@@ -56,7 +56,7 @@
                 "getPreviewValues",
                 "getHarmonizedPreview",
                 "getTransformHeuristics",
-                "getActiveHeuristic"
+                "getHeuristic"
             ]),
 
             transformChoices() {

--- a/cypress/component/annot-continuous-values.cy.js
+++ b/cypress/component/annot-continuous-values.cy.js
@@ -7,7 +7,7 @@ const store = {
 
     getters: {
 
-        getActiveHeuristic: () => (column) => null,
+        getHeuristic: () => (column) => null,
         getHarmonizedPreview: () => (column, missingValue) => null,
         getPreviewValues: () => (activeCategory) => {
             return {
@@ -78,7 +78,7 @@ describe("continuous-values-component", () => {
         cy.mount(annotContinuousValues, {
             propsData: props,
             computed: Object.assign(store.getters, {
-                getActiveHeuristic: () => (column) => "float",
+                getHeuristic: () => (column) => "float",
                 getHarmonizedPreview: () => (column, missingValue) => column + "-" + missingValue + "-harmonized"
             })
         });

--- a/cypress/unit/store-getter-getHeuristic.cy.js
+++ b/cypress/unit/store-getter-getHeuristic.cy.js
@@ -1,0 +1,45 @@
+import { getters } from "~/store";
+
+describe("The column-linking-table component", () => {
+
+    let store = {};
+
+    beforeEach(() => {
+
+        store = {
+
+            state: {
+
+                dataDictionary: {
+
+                    userProvided: {},
+                    annotated: {
+
+                        column1: {}
+                    }
+                }
+            }
+        };
+    });
+
+    it("Get the heuristic of a column with no heuristic", () => {
+
+        // Act
+        const transformationHeuristic = getters.getHeuristic(store.state)("column1");
+
+        // Assert
+        expect(transformationHeuristic).to.equal("");
+    });
+
+    it("Get the heuristic of a column with an already set heuristic", () => {
+
+        // Setup
+        store.state.dataDictionary.annotated.column1.transformationHeuristic = "column1Heuristic";
+
+        // Act
+        const transformationHeuristic = getters.getHeuristic(store.state)("column1");
+
+        // Assert
+        expect(transformationHeuristic).to.equal("column1Heuristic");
+    });
+});

--- a/cypress/unit/store-getter-getHeuristic.cy.js
+++ b/cypress/unit/store-getter-getHeuristic.cy.js
@@ -1,6 +1,6 @@
 import { getters } from "~/store";
 
-describe("The column-linking-table component", () => {
+describe("The getHeuristic getter", () => {
 
     let store = {};
 

--- a/store/index.js
+++ b/store/index.js
@@ -116,6 +116,12 @@ export const getters = {
         return ( 0 === p_state.dataTable.length) ? [] : Object.keys(p_state.dataTable[0] );
     },
 
+    getHeuristic: (p_state) => (p_columnName) => {
+
+        return ( "transformationHeuristic" in p_state.dataDictionary.annotated[p_columnName] ) ?
+            p_state.dataDictionary.annotated[p_columnName].transformationHeuristic : "";
+    },
+
     getNextPage(p_state) {
 
         let nextPage = "";


### PR DESCRIPTION
This completes #266.

1. getter `getHeuristic` returns the `transformationHeuristic` assigned to a particular column in `dataDictionary.annotated`. If the given column has no `transformationHeuristic` key, a blank string is returned
2. Unit tests in `store-getter-getHeuristic.cy.js` test for both of the above scenarios.
3. The naming of the getter is updated in the `annot-continuous-values` component, `getActiveHeuristic` -> `getHeuristic`. The reasoning here is that 'active' referred to the operative heuristic for a particular category, and now that heuristics can vary across columns this is no longer the case.



Moves us one step closer to #336.