### PR TITLE
Refactor getter 'getAnnotationComponent'

### DIFF
--- a/cypress/unit/store-getter-getAnnotationComponent.cy.js
+++ b/cypress/unit/store-getter-getAnnotationComponent.cy.js
@@ -1,0 +1,59 @@
+import { getters } from "~/store";
+
+describe("The getAnnotationComponent getter", () => {
+
+    let store = {};
+
+    beforeEach(() => {
+
+        store = {
+
+            state: {
+
+                categories: {
+
+                    "Subject ID": {},
+                    "Age": {
+
+                        componentName: "annot-continuous-values"
+                    },
+                    "Sex": {
+
+                        componentName: "annot-categorical"
+                    },
+                    "Diagnosis": {
+
+                        componentName: "annot-categorical"
+                    }
+                }
+            }
+        };
+    });
+
+    it("Get the component name for the 'Age' category", () => {
+
+        // Act
+        const componentName = getters.getAnnotationComponent(store.state)("Age");
+
+        // Assert
+        expect(componentName).to.equal("annot-continuous-values");
+    });
+
+    it("Get the component name for the 'Sex' category", () => {
+
+        // Act
+        const componentName = getters.getAnnotationComponent(store.state)("Sex");
+
+        // Assert
+        expect(componentName).to.equal("annot-categorical");
+    });
+
+    it("Get the component name for the 'Diagnosis' category", () => {
+
+        // Act
+        const componentName = getters.getAnnotationComponent(store.state)("Diagnosis");
+
+        // Assert
+        expect(componentName).to.equal("annot-categorical");
+    });
+});

--- a/store/index.js
+++ b/store/index.js
@@ -6,9 +6,18 @@ export const state = () => ({
     categories: {
 
         "Subject ID": {},
-        "Age": {},
-        "Sex": {},
-        "Diagnosis": {}
+        "Age": {
+
+            componentName: "annot-continuous-values"
+        },
+        "Sex": {
+
+            componentName: "annot-categorical"
+        },
+        "Diagnosis": {
+
+            componentName: "annot-categorical"
+        }
     },
 
     colorInfo: {
@@ -90,6 +99,11 @@ export const state = () => ({
 });
 
 export const getters = {
+
+    getAnnotationComponent: (p_state) => (p_category) => {
+
+        return p_state.categories[p_category].componentName;
+    },
 
     getCategoryNames (p_state) {
 


### PR DESCRIPTION
This closes #267.

There is now a getter to retrieve what was once `specializedComponent` in the `annotationDetails` list in the store.

Now the `componentName` (currently `annot-continuous-values` or `annot-categorical`) is listed alongside each category in the `categories` object.

This implementation is accompanied by 3 unit tests for the current categories that are operative on the annotation page: 'Age' (continuous values), 'Sex' and 'Diagnosis' (categorical). There is currently no component for the 'Subject ID' category as this requires no annotation.