### PR TITLE
getMappedColumns Getter for Phase 2 Store Refactor

### DIFF
--- a/cypress/unit/store-getter-getMappedColumns.cy.js
+++ b/cypress/unit/store-getter-getMappedColumns.cy.js
@@ -1,0 +1,29 @@
+import { getters } from "~/store";
+
+const store = {
+
+    state: {
+
+        columnToCategoryMapping: {
+
+            "column1": "category1",
+            "column2": "category2",
+            "column3": "category1"
+        }
+    }
+};
+
+describe("getMappedColumns", () => {
+
+    it("Gets list of columns of a given category", () => {
+
+        // Assert
+        expect(getters.getMappedColumns(store.state)("category1")).to.deep.equal(["column1", "column3"]);
+    });
+
+    it("Gets empty list if a given category is not assigned to any columns", () => {
+
+        // Assert
+        expect(getters.getMappedColumns(store.state)("category4")).to.deep.equal([]);
+    });
+});

--- a/store/index.js
+++ b/store/index.js
@@ -136,6 +136,19 @@ export const getters = {
             p_state.dataDictionary.annotated[p_columnName].transformationHeuristic : "";
     },
 
+    getMappedColumns: (p_state) => (p_category) => {
+
+        const mappedColumns = [];
+        for ( const column in p_state.columnToCategoryMapping ) {
+
+            if ( p_category === p_state.columnToCategoryMapping[column] ) {
+
+                mappedColumns.push(column);
+            }
+        }
+        return mappedColumns;
+    },
+
     getNextPage(p_state) {
 
         let nextPage = "";


### PR DESCRIPTION
This closes #273.

A new getter, `getMappedColumns` has been introduced to the store that retrieves a list of columns given a category.

Two unit tests for this getter have been implemented as well, one that looks for a correct list of columns and another that looks for an empty list given a category to which no data table columns have been linked.