### PR TITLE
Getter getMissingValues for Phase 2 Store Refactor

### DIFF
--- a/components/annot-missing-values.vue
+++ b/components/annot-missing-values.vue
@@ -69,7 +69,7 @@
 
             ...mapGetters([
 
-                "missingValues",
+                "getMissingValues",
                 "getValueDescription"
             ]),
 
@@ -77,7 +77,7 @@
                 // Returns an array of objects, with one object for each missing value
                 // in the columns assigned to the activeCategory
                 // for display in the missing Value Table
-                return Object.entries(this.missingValues(this.activeCategory)).map(([column, missingValues]) => {
+                return Object.entries(this.getMissingValues(this.activeCategory)).map(([column, missingValues]) => {
                     return missingValues.map(missingValue => {
                         return {
                             column: column,

--- a/cypress/unit/store-getter-getMissingValues.cy.js
+++ b/cypress/unit/store-getter-getMissingValues.cy.js
@@ -5,6 +5,13 @@ const store = {
     getters: getters,
     state: {
 
+        columnToCategoryMapping: {
+
+            column1: "category1",
+            column2: "category1",
+            column3: "category2"
+        },
+
         dataDictionary: {
 
             annotated: {
@@ -14,7 +21,12 @@ const store = {
                     missingValues: [1, 2, 3]
                 },
 
-                column2: {}
+                column2: {
+
+                    missingValues: [4, 5, 6]
+                },
+
+                column3: {}
             }
         }
     }
@@ -22,30 +34,33 @@ const store = {
 
 describe("getMissingValues", () => {
 
-    it("Retrieves the missing values of a column that has missing values", () => {
+    it("Retrieves the missing values of a category that has columns with missing values", () => {
 
         // Act
-        const missingValues = store.getters.getMissingValues(store.state)("column1");
+        const missingValues = store.getters.getMissingValues(store.state)("category1");
 
         // Assert
-        expect(missingValues).to.deep.equal([1, 2, 3]);
+        expect(missingValues).to.deep.equal({
+            column1: [1, 2, 3],
+            column2: [4, 5, 6]
+        });
     });
 
-    it("Attempts to retrieve the missing values of a column has *no* missing values", () => {
+    it("Attempts to retrieve the missing values of a category has a column with no missing values", () => {
 
         // Act
-        const missingValues = store.getters.getMissingValues(store.state)("column2");
+        const missingValues = store.getters.getMissingValues(store.state)("category2");
 
         // Assert
-        expect(missingValues).to.deep.equal([]);
+        expect(missingValues).to.deep.equal({ column3: [] });
     });
 
-    it("Attempts to retrieve the missing values of a column has *no* entry in the data dictionary", () => {
+    it("Attempts to retrieve the missing values of a category has *no* linked columns", () => {
 
         // Act
-        const missingValues = store.getters.getMissingValues(store.state)("column3");
+        const missingValues = store.getters.getMissingValues(store.state)("category3");
 
         // Assert
-        expect(missingValues).to.deep.equal([]);
+        expect(missingValues).to.deep.equal({});
     });
 });

--- a/cypress/unit/store-getter-getMissingValues.cy.js
+++ b/cypress/unit/store-getter-getMissingValues.cy.js
@@ -1,0 +1,51 @@
+import { getters } from "~/store";
+
+const store = {
+
+    getters: getters,
+    state: {
+
+        dataDictionary: {
+
+            annotated: {
+
+                column1: {
+
+                    missingValues: [1, 2, 3]
+                },
+
+                column2: {}
+            }
+        }
+    }
+};
+
+describe("getMissingValues", () => {
+
+    it("Retrieves the missing values of a column that has missing values", () => {
+
+        // Act
+        const missingValues = store.getters.getMissingValues(store.state)("column1");
+
+        // Assert
+        expect(missingValues).to.deep.equal([1, 2, 3]);
+    });
+
+    it("Attempts to retrieve the missing values of a column has *no* missing values", () => {
+
+        // Act
+        const missingValues = store.getters.getMissingValues(store.state)("column2");
+
+        // Assert
+        expect(missingValues).to.deep.equal([]);
+    });
+
+    it("Attempts to retrieve the missing values of a column has *no* entry in the data dictionary", () => {
+
+        // Act
+        const missingValues = store.getters.getMissingValues(store.state)("column3");
+
+        // Assert
+        expect(missingValues).to.deep.equal([]);
+    });
+});

--- a/store/index.js
+++ b/store/index.js
@@ -158,6 +158,19 @@ export const getters = {
         return mappedColumns;
     },
 
+    getMissingValues: (p_state) => (p_column) => {
+
+        let missingValues = [];
+
+        if ( p_column in p_state.dataDictionary.annotated &&
+             "missingValues" in p_state.dataDictionary.annotated[p_column] ) {
+
+            missingValues = p_state.dataDictionary.annotated[p_column].missingValues;
+        }
+
+        return missingValues;
+    },
+
     getNextPage(p_state) {
 
         let nextPage = "";

--- a/store/index.js
+++ b/store/index.js
@@ -172,14 +172,33 @@ export const getters = {
         return mappedColumns;
     },
 
-    getMissingValues: (p_state) => (p_column) => {
+    getMissingValues: (p_state) => (p_category) => {
 
-        let missingValues = [];
+        // 0. Retrieve all columns linked with the given category
+        const mappedColumns = [];
+        for ( const column in p_state.columnToCategoryMapping ) {
 
-        if ( p_column in p_state.dataDictionary.annotated &&
-             "missingValues" in p_state.dataDictionary.annotated[p_column] ) {
+            if ( p_category === p_state.columnToCategoryMapping[column] ) {
 
-            missingValues = p_state.dataDictionary.annotated[p_column].missingValues;
+                mappedColumns.push(column);
+            }
+        }
+
+        // 1. Build a map of missing values by column
+        let missingValues = {};
+        for ( const column of mappedColumns ) {
+
+            // A. Starts out as a blank list
+            missingValues[column] = [];
+
+            // B. Save a list of missing values for this column if,
+            // 1) the column has an entry in the data dictionary and,
+            // 2) if a missing values list for the column has already been made
+            if ( column in p_state.dataDictionary.annotated &&
+                "missingValues" in p_state.dataDictionary.annotated[column] ) {
+
+               missingValues[column] = p_state.dataDictionary.annotated[column].missingValues;
+           }
         }
 
         return missingValues;


### PR DESCRIPTION
This closes #278.

This PR implements a getter for retrieving any values that have been marked as "missing' for a particular given column in the annotated data dictionary. The expectation is that if there are any missing values they will be stored in `dataDictionary.annotated.<columnName>.missingValues`.

Also implemented are unit tests for three scenarios for this getter:
1. Retrieving the missing values list from`dataDictionary.annotated.<columnName>.missingValues`
2. Returning an empty list if there are no missing values (no `missingValues` key) in the column entr in the `dataDictionary.annotated` object
3. Returning an empty list if the column itself is not listed in `dataDictionary.annotated`

This is related to #275 - which will be implemented following this PR.