### PR TITLE
Missing values table items refactor + component test fix

### DIFF
--- a/components/annot-missing-values.vue
+++ b/components/annot-missing-values.vue
@@ -74,19 +74,26 @@
             ]),
 
             tableItems() {
-                // Returns an array of objects, with one object for each missing value
-                // in the columns assigned to the activeCategory
-                // for display in the missing Value Table
-                return Object.entries(this.getMissingValues(this.activeCategory)).map(([column, missingValues]) => {
-                    return missingValues.map(missingValue => {
-                        return {
+
+                // 0. Retrieve the missing values for each column linked to the active category
+                const missingValuesForCategory = this.getMissingValues(this.activeCategory);
+
+                // 1. Construct an array of objects with one object for each missing value
+                // that each includes its column name, description, and the value itself
+                const tableItems = [];
+                for ( const column in missingValuesForCategory ) {
+                    for ( const value of missingValuesForCategory[column] ) {
+
+                        tableItems.push({
+
                             column: column,
-                            description: this.getValueDescription(column, missingValue),
-                            value: missingValue
-                        };
-                    });
+                            description: this.getValueDescription(column, value),
+                            value: value
+                        });
+                    }
                 }
-                ).flat();
+
+                return tableItems;
             }
         },
 

--- a/cypress/component/annot-missing-values.cy.js
+++ b/cypress/component/annot-missing-values.cy.js
@@ -3,56 +3,71 @@ import annotMissingValues from "~/components/annot-missing-values";
 
 // Mocked Store getters
 const store = {
+
     getters: {
-        getValueDescription: () => (column, missingValue) => missingValue + " from " + column,
-        missingValues: () => (category) => {
+
+        getMissingValues: () => (p_category) => {
+
             return {
-                "column1": ["val1", "val2"],
-                "column2": ["val3"]
+
+                column1: ["val1", "val2"],
+                column2: ["val3"]
             };
-        }
+        },
+        getValueDescription: () => (p_column, p_missingValue) => p_missingValue + " from " + p_column
     }
 };
 
 const props = {
+
     activeCategory: "category1"
 };
 
-describe("missing values", () => {
+describe("Missing values", () => {
 
-        it('displays unique values and description', () => {
+        it("Displays unique values and description", () => {
+
+                // Act
                 cy.mount(annotMissingValues, {
                         propsData: props,
                         computed: store.getters
                     }
                 );
-                cy.get('.missing-values-card-body').contains('val1 from column1');
+
+                // Assert
+                cy.get(".missing-values-card-body").contains("val1 from column1");
             }
         );
 
-        it('handles lack of description gracefully', () => {
+        it("Handles lack of description gracefully", () => {
+
+                // Act
                 cy.mount(annotMissingValues, {
                         propsData: props,
-                        computed: Object.assign(store.getters, {valueDescription: () => (col, mis) => null})
+                        computed: Object.assign(store.getters, { description: () => (p_column, p_missingValues) => null })
                     }
                 );
             }
         );
 
-        it("can be declared 'not missing' by clicking the 'Not Missing' button", () => {
-                const mockStore = {commit: () => {}};
-                cy.spy(mockStore, 'commit').as('commitSpy');
+        it("Can be declared 'not missing' by clicking the 'Not Missing' button", () => {
 
+                // Setup
+                const mockStore = { commit: () => {} };
+                cy.spy(mockStore, "commit").as("commitSpy");
                 cy.mount(annotMissingValues, {
-                        propsData: props,
-                        computed: store.getters,
-                        mocks: {
-                            $store: mockStore
-                        }
-                    }
-                );
+                    computed: store.getters,
+                    mocks: {
+                        $store: mockStore
+                    },
+                    propsData: props
+                });
+
+                // Act
                 cy.get("[data-cy='not-missing-button-column1-val1']").click();
-                cy.get("@commitSpy").should('have.been.calledWith', "declareNotMissing", {column: "column1", value: "val1"});
+
+                // Assert
+                cy.get("@commitSpy").should("have.been.calledWith", "declareNotMissing", { column: "column1", value: "val1" });
             }
         );
     }


### PR DESCRIPTION
This PR

1. Simplifies the implementation of the `tableItems` function in the `annot-missing-values` component
1. Fixes the `annot-missing-values` component test that was broken by #355 (a name change for the use of the `getMissingValues` getter in `annot-missing-values`).
2. Formats the `annot-missing-values` component test