### PR TITLE
mutation 'changeMissingStatus' for Phase 2 Store Refactor

### DIFF
--- a/components/annot-categorical.vue
+++ b/components/annot-categorical.vue
@@ -31,7 +31,7 @@
                         <b-button
                             :data-cy="'missingValueButton_' + row.index"
                             variant="danger"
-                            @click="designateAsMissing(row.item['columnName'], row.item['rawValue'])">
+                            @click="changeMissingStatus(row.item['columnName'], row.item['rawValue'], true)">
                             {{ uiText.missingValueButton }}
                         </b-button>
                     </template>
@@ -119,8 +119,8 @@
 
             ...mapMutations([
 
-                "selectAnOption",
-                "designateAsMissing"
+                "changeMissingStatus",
+                "selectAnOption"
             ])
         }
     };

--- a/components/annot-missing-values.vue
+++ b/components/annot-missing-values.vue
@@ -104,13 +104,13 @@
                 "changeMissingStatus"
             ]),
 
-            removeValue(tableItem) {
+            removeValue(p_tableItem) {
 
                 // Remove this value from the column's missing value list in the store
                 this.changeMissingStatus({
-                    column: tableItem.column,
-                    markAsMissing: true,
-                    value: tableItem.value
+                    column: p_tableItem.column,
+                    markAsMissing: false,
+                    value: p_tableItem.value
                 });
             }
         }

--- a/components/annot-missing-values.vue
+++ b/components/annot-missing-values.vue
@@ -98,14 +98,20 @@
         },
 
         methods: {
+
             ...mapMutations([
-                "declareNotMissing"
+
+                "changeMissingStatus"
             ]),
 
             removeValue(tableItem) {
 
                 // Remove this value from the column's missing value list in the store
-                this.declareNotMissing({column: tableItem.column, value: tableItem.value});
+                this.changeMissingStatus({
+                    column: tableItem.column,
+                    markAsMissing: true,
+                    value: tableItem.value
+                });
             }
         }
     };

--- a/cypress/component/annot-categorical.cy.js
+++ b/cypress/component/annot-categorical.cy.js
@@ -101,7 +101,7 @@ describe("Categorical annotation", () => {
         cy.get("[data-cy='categoricalSelector_1']").contains("option_1");
     });
 
-    it("displays the missing value button and designates value as missing when clicked", () => {
+    it("Displays the missing value button and designates value as missing when clicked", () => {
 
         // Setup
         cy.spy(store, "commit").as("commitSpy");
@@ -120,6 +120,6 @@ describe("Categorical annotation", () => {
         cy.get("[data-cy='missingValueButton_1']").click();
 
         // Assert
-        cy.get("@commitSpy").should("have.been.calledOnceWith", "designateAsMissing", "column1", "HC");
+        cy.get("@commitSpy").should("have.been.calledOnceWith", "changeMissingStatus", "column1", "HC", true);
     });
 });

--- a/cypress/component/annot-continuous-values.cy.js
+++ b/cypress/component/annot-continuous-values.cy.js
@@ -24,7 +24,7 @@ const store = {
 
     mutations: {
 
-        designateAsMissing: () => (p_columnName, p_rawValue) => {},
+        changeMissingStatus: () => (p_columnName, p_rawValue, p_markAsMissing) => {},
         setHeuristic: () => (p_state, { p_column, p_heuristic }) => {}
     }
 };

--- a/cypress/component/annot-missing-values.cy.js
+++ b/cypress/component/annot-missing-values.cy.js
@@ -67,7 +67,7 @@ describe("Missing values", () => {
                 cy.get("[data-cy='not-missing-button-column1-val1']").click();
 
                 // Assert
-                cy.get("@commitSpy").should("have.been.calledWith", "changeMissingStatus", { column: "column1", value: "val1", markAsMissing: true });
+                cy.get("@commitSpy").should("have.been.calledWith", "changeMissingStatus", { column: "column1", value: "val1", markAsMissing: false });
             }
         );
     }

--- a/cypress/component/annot-missing-values.cy.js
+++ b/cypress/component/annot-missing-values.cy.js
@@ -67,7 +67,7 @@ describe("Missing values", () => {
                 cy.get("[data-cy='not-missing-button-column1-val1']").click();
 
                 // Assert
-                cy.get("@commitSpy").should("have.been.calledWith", "declareNotMissing", { column: "column1", value: "val1" });
+                cy.get("@commitSpy").should("have.been.calledWith", "changeMissingStatus", { column: "column1", value: "val1", markAsMissing: true });
             }
         );
     }

--- a/cypress/unit/store-mutation-changeMissingStatus.cy.js
+++ b/cypress/unit/store-mutation-changeMissingStatus.cy.js
@@ -1,0 +1,51 @@
+import { mutations } from "~/store";
+
+let store;
+
+describe("changeMissingStatus mutation", () => {
+
+    // Setup
+    beforeEach(() => {
+
+        store = {
+
+            state: {
+
+                missingValues: {
+
+                    column1: []
+                }
+            }
+        };
+    });
+
+    it("Mark a value as missing", () => {
+
+        // Act
+        mutations.changeMissingStatus(store.state, {
+            column: "column1",
+            markAsMissing: true,
+            value: "value1"
+        });
+
+        // Assert
+        expect(store.state.missingValues.column1).to.include("value1");
+    });
+
+    it("Remove missing status of a value", () => {
+
+        // Setup
+        store.state.missingValues.column1.push("value1");
+
+        // Act
+        mutations.changeMissingStatus(store.state, {
+            column: "column1",
+            markAsMissing: false,
+            value: "value1"
+        });
+
+        // Assert
+        expect(store.state.missingValues.column1).to.not.include("value1");
+    });
+
+});

--- a/store/index.js
+++ b/store/index.js
@@ -339,6 +339,15 @@ export const mutations = {
 
     },
 
+    changeMissingStatus(p_state, { column, value, markAsMissing }) {
+
+        if ( markAsMissing ) {
+            p_state.missingValues[column].push(value);
+        } else {
+            p_state.missingValues[column].splice(p_state.missingValues[column].indexOf(value), 1);
+        }
+    },
+
     initializeColumnToCategoryMap(p_state, p_columns) {
 
         // Column to category map lists all columns as keys with default value of null


### PR DESCRIPTION
This PR closes #275 by implementing the following:

1. A mutation `changeMissingStatus` that takes a column name, value, and a boolean flag indicating whether or not the value should be marked as missing or its missing status should be removed.
2. A unit test for `changeMissingStatus` in `store-mutation-changeMissingStatus.cy.js` that tests adding and removing the missing status of a value.
3. Previous uses of the functions `designateAsMissing` and `declareAsNotMissing` in `annot-categorical` and `annot-missing-values` have been converted into using the more general `changeMissingStatus` mutation.
4. An unused reference to `designateAsMissing` in the test for `annot-continuous-values` (ostensibly for a future 'mark as missing' feature for this component) has been amended for the new mutation name and parameters.