### PR TITLE
getUniqueValues getter for Phase 2 Store Refactor

### DIFF
--- a/components/annot-categorical.vue
+++ b/components/annot-categorical.vue
@@ -100,15 +100,21 @@
 
             displayTable() {
 
-                // Create and return table data for the unique values in the relevant columns that are not missing values
-                const tableData = [];
-                for ( const row of this.getUniqueValues(this.activeCategory) ) {
+                // 0. Retrieve all unique values for columns linked to the active category
+                const uniqueValuesMap = this.getUniqueValues(this.activeCategory);
 
-                    tableData.push({
-                        columnName: row.columnName,
-                        description: this.getValueDescription(row.columnName, row.rawValue),
-                        rawValue: row.rawValue
-                    });
+                // 1. Create and return table data for the unique values in the relevant columns that are not missing values
+                const tableData = [];
+
+                for ( const columnName in uniqueValuesMap ) {
+                    for ( const uniqueValue of uniqueValuesMap[columnName]) {
+
+                        tableData.push({
+                            columnName: columnName,
+                            description: this.getValueDescription(columnName, uniqueValue),
+                            rawValue: uniqueValue
+                        });
+                    }
                 }
 
                 return tableData;

--- a/cypress/component/annot-categorical.cy.js
+++ b/cypress/component/annot-categorical.cy.js
@@ -20,12 +20,11 @@ const store = {
 
         getUniqueValues: () => (p_activeCategory) => {
 
-            return [
-                { columnName: "column1", rawValue: "PD" },
-                { columnName: "column1", rawValue: "HC" },
-                { columnName: "column2", rawValue: "" },
-                { columnName: "column2", rawValue: "oups" }
-            ];
+            return {
+
+                column1: ["PD", "HC"],
+                column2: ["", "oups"]
+            };
         },
 
         getValueDescription: () => (p_column, p_cellValue) => {

--- a/cypress/unit/store-getter-getUniqueValues.cy.js
+++ b/cypress/unit/store-getter-getUniqueValues.cy.js
@@ -13,15 +13,26 @@ describe("getUniqueValues getter", () => {
                 columnToCategoryMapping: {
 
                     column1: "Diagnosis",
-                    column2: "Age"
+                    column2: "Age",
+                    column3: "Sex"
+                },
+
+                dataDictionary: {
+
+                    annotated: {
+
+                        column1: { missingValues: [] },
+                        column2: { missingValues: [] },
+                        column3: { missingValues: ["column3_value1", "column3_value2"] }
+                    }
                 },
 
                 dataTable: [
 
-                    { column1: 1, column2: "column2_value1" },
-                    { column1: 2, column2: "column2_value2" },
-                    { column1: 1, column2: "column2_value3" },
-                    { column1: 3, column2: "column2_value2" }
+                    { column1: 1, column2: "column2_value1", column3: "column3_value1" },
+                    { column1: 2, column2: "column2_value2", column3: "column3_value2" },
+                    { column1: 1, column2: "column2_value3", column3: "column3_value3" },
+                    { column1: 3, column2: "column2_value2", column3: "column3_value4" }
                 ]
             }
         };
@@ -30,10 +41,10 @@ describe("getUniqueValues getter", () => {
     it("Retrieves unique values of a single column", () => {
 
         // Act
-        const diagnosisUniqueValues = getters.getUniqueValues(store)("Diagnosis");
+        const diagnosisUniqueValues = getters.getUniqueValues(store.state)("Diagnosis");
 
         // Assert
-        expect(diagnosisUniqueValues).to.deep.equal({ "column1": [1, 2, 3]});
+        expect(diagnosisUniqueValues).to.deep.equal({ "column1": [1, 2, 3] });
     });
 
     it("Retrieves unique values of a multiple columns", () => {
@@ -42,22 +53,31 @@ describe("getUniqueValues getter", () => {
         store.state.columnToCategoryMapping.column2 = "Diagnosis";
 
         // Act
-        const diagnosisUniqueValues = getters.getUniqueValues(store)("Diagnosis");
+        const diagnosisUniqueValues = getters.getUniqueValues(store.state)("Diagnosis");
 
         // Assert
         expect(diagnosisUniqueValues).to.deep.equal({
 
-            column1: [1, 2, 3],
-            column2: ["column2_value1", "column2_value2", "column2_value3"]
+            "column1": [1, 2, 3],
+            "column2": ["column2_value1", "column2_value2", "column2_value3"]
         });
     });
 
     it("Retrieve unique value list of maximum length", () => {
 
         // Act
-        const diagnosisUniqueValues = getters.getUniqueValues(store)("Diagnosis", 2);
+        const diagnosisUniqueValues = getters.getUniqueValues(store.state)("Diagnosis", 2);
 
         // Assert
         expect(diagnosisUniqueValues).to.deep.equal({ "column1": [1, 2]});
+    });
+
+    it("Make sure no missing values are included in unique values", () => {
+
+        // Act
+        const diagnosisUniqueValues = getters.getUniqueValues(store.state)("Sex");
+
+        // Assert
+        expect(diagnosisUniqueValues).to.deep.equal({ "column3": ["column3_value3", "column3_value4"]});
     });
 });

--- a/cypress/unit/store-getter-getUniqueValues.cy.js
+++ b/cypress/unit/store-getter-getUniqueValues.cy.js
@@ -1,0 +1,63 @@
+import { getters } from "~/store";
+
+let store;
+
+describe("getUniqueValues getter", () => {
+
+    beforeEach(() => {
+
+        store = {
+
+            state: {
+
+                columnToCategoryMapping: {
+
+                    column1: "Diagnosis",
+                    column2: "Age"
+                },
+
+                dataTable: [
+
+                    { column1: 1, column2: "column2_value1" },
+                    { column1: 2, column2: "column2_value2" },
+                    { column1: 1, column2: "column2_value3" },
+                    { column1: 3, column2: "column2_value2" }
+                ]
+            }
+        };
+    });
+
+    it("Retrieves unique values of a single column", () => {
+
+        // Act
+        const diagnosisUniqueValues = getters.getUniqueValues(store)("Diagnosis");
+
+        // Assert
+        expect(diagnosisUniqueValues).to.deep.equal({ "column1": [1, 2, 3]});
+    });
+
+    it("Retrieves unique values of a multiple columns", () => {
+
+        // Setup
+        store.state.columnToCategoryMapping.column2 = "Diagnosis";
+
+        // Act
+        const diagnosisUniqueValues = getters.getUniqueValues(store)("Diagnosis");
+
+        // Assert
+        expect(diagnosisUniqueValues).to.deep.equal({
+
+            column1: [1, 2, 3],
+            column2: ["column2_value1", "column2_value2", "column2_value3"]
+        });
+    });
+
+    it("Retrieve unique value list of maximum length", () => {
+
+        // Act
+        const diagnosisUniqueValues = getters.getUniqueValues(store)("Diagnosis", 2);
+
+        // Assert
+        expect(diagnosisUniqueValues).to.deep.equal({ "column1": [1, 2]});
+    });
+});

--- a/store/index.js
+++ b/store/index.js
@@ -243,7 +243,7 @@ export const getters = {
 
     getUniqueValues: (p_state) => (p_category, p_maxValues="None") => {
 
-        // 1. Construct a list of unique values for each column
+        // 1. Construct an object containing a list of unique values for each column
         const uniqueValues = {};
         for ( const columnName in p_state.columnToCategoryMapping ) {
 
@@ -275,7 +275,7 @@ export const getters = {
             }
         }
 
-        // Return a list of objects
+        // Return an object containing a list of unique values for each column
         return uniqueValues;
     },
 

--- a/store/index.js
+++ b/store/index.js
@@ -1,4 +1,5 @@
 // Facilitate Vue reactivity via 'Vue.set' and 'Vue.delete'
+import { Set } from "core-js";
 import Vue from "vue";
 
 export const state = () => ({
@@ -238,6 +239,40 @@ export const getters = {
 
         // Return the set of transformation heuristics for this data type
         return p_state.transformationHeuristics[columnDataType];
+    },
+
+    getUniqueValues: (p_state) => (p_category, p_maxValues="None") => {
+
+        // NEXT: Debug this function next to help pass unit test
+
+        // 1. Construct a list of unique values for each column
+        const uniqueValues = {};
+        for ( const column in p_state.columnToCategoryMapping ) {
+
+            // A. Create a new list for values for each column linked to the given category
+            if ( p_category === p_state.columnToCategoryMapping[column] ) {
+
+                // I. Save unique values for each column
+                uniqueValues[column] = new Set();
+                for ( let index = 0; index < p_state.dataTable.length; index++ ) {
+
+                    uniqueValues[column].add(p_state.dataTable[index][column]);
+                }
+
+                // II. Convert the unique values list for this column from a set to an array
+                uniqueValues[column] = [...uniqueValues[column]];
+
+                // III. Trim the value list if a maximum value amount was given
+                // NOTE: Trimming is done here instead of only looking at p_maxValues rows
+                // just in case there are blank entries for columns in the data table
+                if ( "None" !== p_maxValues ) {
+
+                    uniqueValues[column] = uniqueValues[column].slice(0, p_maxValues);
+                }
+            }
+        }
+
+        return uniqueValues;
     },
 
     getValueDescription: (p_state) => (p_columnName, p_value) => {

--- a/store/index.js
+++ b/store/index.js
@@ -243,35 +243,39 @@ export const getters = {
 
     getUniqueValues: (p_state) => (p_category, p_maxValues="None") => {
 
-        // NEXT: Debug this function next to help pass unit test
-
         // 1. Construct a list of unique values for each column
         const uniqueValues = {};
-        for ( const column in p_state.columnToCategoryMapping ) {
+        for ( const columnName in p_state.columnToCategoryMapping ) {
 
             // A. Create a new list for values for each column linked to the given category
-            if ( p_category === p_state.columnToCategoryMapping[column] ) {
+            if ( p_category === p_state.columnToCategoryMapping[columnName] ) {
 
                 // I. Save unique values for each column
-                uniqueValues[column] = new Set();
+                uniqueValues[columnName] = new Set();
                 for ( let index = 0; index < p_state.dataTable.length; index++ ) {
 
-                    uniqueValues[column].add(p_state.dataTable[index][column]);
+                    // a. Check to see if this value is marked as 'missing' for this column
+                    let value = p_state.dataTable[index][columnName];
+                    if ( !p_state.dataDictionary.annotated[columnName].missingValues.includes(value) ) {
+
+                        uniqueValues[columnName].add(value);
+                    }
                 }
 
                 // II. Convert the unique values list for this column from a set to an array
-                uniqueValues[column] = [...uniqueValues[column]];
+                uniqueValues[columnName] = [...uniqueValues[columnName]];
 
                 // III. Trim the value list if a maximum value amount was given
                 // NOTE: Trimming is done here instead of only looking at p_maxValues rows
                 // just in case there are blank entries for columns in the data table
                 if ( "None" !== p_maxValues ) {
 
-                    uniqueValues[column] = uniqueValues[column].slice(0, p_maxValues);
+                    uniqueValues[columnName] = uniqueValues[columnName].slice(0, p_maxValues);
                 }
             }
         }
 
+        // Return a list of objects
         return uniqueValues;
     },
 


### PR DESCRIPTION
This PR closes #277 by implementing the following:

1. `getUniqueValues` getter in the store that takes every column linked to a given category and gathers unique values for each column via the `dataTable`. The getter outputs an object keyed on column with values that are an array of the unique values for that column. Missing values are skipped via lookup in the `dataDictionary`
2. `getUniqueValues` also takes an optional parameter `maxValues` to limit how many values are returned
3. `displayItems` in the `annot-categorical` component has been rewritten to accommodate the new output of `getUniqueValues`
4. Unit tests for this getter in `store-getter-getUniqueValues.cy.js` test the following scenarios: a) unique values for a single column, b) unique values for multiple columns, c) retrieving unique values with the optional maximum amount argument, and d) ensuring that no 'missing' values are returned with the unique values