### PR TITLE
changeMissingStatus getter Fix + Check for Unique Values

### DIFF
--- a/cypress/unit/store-mutation-changeMissingStatus.cy.js
+++ b/cypress/unit/store-mutation-changeMissingStatus.cy.js
@@ -15,7 +15,10 @@ describe("changeMissingStatus mutation", () => {
 
                     annotated: {
 
-                        column1: []
+                        column1: {
+
+                            missingValues: []
+                        }
                     }
                 }
             }
@@ -32,13 +35,13 @@ describe("changeMissingStatus mutation", () => {
         });
 
         // Assert
-        expect(store.state.dataDictionary.annotated.column1).to.include("value1");
+        expect(store.state.dataDictionary.annotated.column1.missingValues).to.include("value1");
     });
 
     it("Remove missing status of a value", () => {
 
         // Setup
-        store.state.dataDictionary.annotated.column1.push("value1");
+        store.state.dataDictionary.annotated.column1.missingValues.push("value1");
 
         // Act
         mutations.changeMissingStatus(store.state, {
@@ -48,7 +51,7 @@ describe("changeMissingStatus mutation", () => {
         });
 
         // Assert
-        expect(store.state.dataDictionary.annotated.column1).to.not.include("value1");
+        expect(store.state.dataDictionary.annotated.column1.missingValues).to.not.include("value1");
     });
 
 });

--- a/cypress/unit/store-mutation-changeMissingStatus.cy.js
+++ b/cypress/unit/store-mutation-changeMissingStatus.cy.js
@@ -54,4 +54,20 @@ describe("changeMissingStatus mutation", () => {
         expect(store.state.dataDictionary.annotated.column1.missingValues).to.not.include("value1");
     });
 
+    it("Mark a value as missing twice; list only contains it once", () => {
+
+        // Setup
+        store.state.dataDictionary.annotated.column1.missingValues.push("value1");
+        store.state.dataDictionary.annotated.column1.missingValues.push("value1");
+
+        // Act
+        mutations.changeMissingStatus(store.state, {
+            column: "column1",
+            markAsMissing: false,
+            value: "value1"
+        });
+
+        // Assert
+        expect(store.state.dataDictionary.annotated.column1.missingValues).to.deep.equal(["value1"]);
+    });
 });

--- a/store/index.js
+++ b/store/index.js
@@ -342,8 +342,13 @@ export const mutations = {
     changeMissingStatus(p_state, { column, value, markAsMissing }) {
 
         if ( markAsMissing ) {
-            p_state.dataDictionary.annotated[column].missingValues.push(value);
+
+            if ( !p_state.dataDictionary.annotated[column].missingValues.includes(value) ) {
+
+                p_state.dataDictionary.annotated[column].missingValues.push(value);
+            }
         } else {
+
             p_state.dataDictionary.annotated[column].missingValues.splice(
                 p_state.dataDictionary.annotated[column].missingValues.indexOf(value), 1);
         }

--- a/store/index.js
+++ b/store/index.js
@@ -342,9 +342,10 @@ export const mutations = {
     changeMissingStatus(p_state, { column, value, markAsMissing }) {
 
         if ( markAsMissing ) {
-            p_state.dataDictionary.annotated[column].push(value);
+            p_state.dataDictionary.annotated[column].missingValues.push(value);
         } else {
-            p_state.dataDictionary.annotated[column].splice(p_state.dataDictionary.annotated[column].indexOf(value), 1);
+            p_state.dataDictionary.annotated[column].missingValues.splice(
+                p_state.dataDictionary.annotated[column].missingValues.indexOf(value), 1);
         }
     },
 


### PR DESCRIPTION
This PR closes #171  and #364 by implementing the following:

1. Ensuring missing values are added/removed from the `missingValues` list that will exist for each column in `dataDictionary.annotated`
2. Add a uniqueness check to the add value case in `changeMissingStatus`
3. Updating unit tests for `checkMissingStatus` to properly add/remove from `missingValues` lists
4. Additional unit test to ensure no duplicate values can be added to the `missingValues` list in `dataDictionary.annotated.<column>`.