### PR TITLE
selectCategoricalOption mutation for Phase 2 Store Refactor

### DIFF
--- a/components/annot-categorical.vue
+++ b/components/annot-categorical.vue
@@ -24,7 +24,7 @@
                         <v-select
                             :data-cy="'categoricalSelector' + '_' + row.index"
                             :value="getSelectedOption(row.index)"
-                            @input="selectAnOption($event, row.item['columnName'], row.item['rawValue'])"
+                            @input="selectCategoricalOption($event, row.item['columnName'], row.item['rawValue'])"
                             :options="getCategoricalOptions(row.item['columnName'])" />
                     </template>
                     <template #cell(missingValue)="row">
@@ -120,7 +120,7 @@
             ...mapMutations([
 
                 "changeMissingStatus",
-                "selectAnOption"
+                "selectCategoricalOption"
             ])
         }
     };

--- a/cypress/component/annot-categorical.cy.js
+++ b/cypress/component/annot-categorical.cy.js
@@ -37,7 +37,7 @@ const store = {
     mutations: {
 
         designateAsMissing: () => (p_columnName, p_rawValue) => {},
-        selectAnOption: () => (p_option, p_columnName, p_rawValue) => {}
+        selectCategoricalOption: () => (p_option, p_columnName, p_rawValue) => {}
     }
 };
 
@@ -86,7 +86,7 @@ describe("Categorical annotation", () => {
         cy.get("[data-cy='categoricalSelector_0']").click().contains("option_2").click();
 
         // Assert
-        cy.get("@commitSpy").should("have.been.calledOnceWith", "selectAnOption", "option_2", "column1", "PD");
+        cy.get("@commitSpy").should("have.been.calledOnceWith", "selectCategoricalOption", "option_2", "column1", "PD");
     });
 
     it("Displays the preset mapping in the dropdown", () => {

--- a/cypress/unit/store-mutation-selectCategoricalOption.cy.js
+++ b/cypress/unit/store-mutation-selectCategoricalOption.cy.js
@@ -1,0 +1,51 @@
+import { mutations } from "~/store";
+
+let store;
+
+describe("selectCategoricalOption mutation", () => {
+
+    beforeEach(() => {
+
+        store = {
+
+            state: {
+
+                dataDictionary: {
+
+                    annotated: {
+
+                        column1: {}
+                    }
+                }
+            }
+        };
+    });
+
+    it("Makes sure a value map is created for a column in the data dictionary", () => {
+
+        // Act
+        mutations.selectCategoricalOption(store.state, "female", "column1", "F");
+
+        // Assert
+        expect(store.state.dataDictionary.annotated.column1.valueMap).to.exist;
+    });
+
+    it("Makes sure an annotated value is set in the value map", () => {
+
+        // Act
+        mutations.selectCategoricalOption(store.state, "female", "column1", "F");
+
+        // Assert
+        expect(store.state.dataDictionary.annotated.column1.valueMap["F"]).to.equal("female");
+    });
+
+    it("Makes sure a value in the value map can be overwritten", () => {
+
+        // Act
+        mutations.selectCategoricalOption(store.state, "female", "column1", "F");
+        mutations.selectCategoricalOption(store.state, "female", "column1", "Female");
+
+        // Assert
+        expect(store.state.dataDictionary.annotated.column1.valueMap["Female"]).to.equal("female");
+    });
+});

--- a/store/index.js
+++ b/store/index.js
@@ -370,6 +370,18 @@ export const mutations = {
         p_state.dataDictionary.annotated = JSON.parse(JSON.stringify(p_state.dataDictionary.userProvided));
     },
 
+    selectCategoricalOption(p_state, p_optionValue, p_columnName, p_rawValue) {
+
+        // 0. Create an categorical value map for this column, if it does not yet exist
+        if ( !("valueMap" in p_state.dataDictionary.annotated[p_columnName]) ) {
+
+            p_state.dataDictionary.annotated[p_columnName].valueMap = {};
+        }
+
+        // 1. Assign the option value to a raw value for this column
+        p_state.dataDictionary.annotated[p_columnName].valueMap[p_rawValue] = p_optionValue;
+    },
+
     setCurrentPage(p_state, p_pageName) {
 
         p_state.currentPage = p_pageName;


### PR DESCRIPTION
This PR closes #274 by implementing the following:

1. `selectCategoricalOption` mutation in the store that takes a column name, option value and raw value and a) creates a `valueMap` object on `dataDictionary.annotated.<column_name>` if it does not exist, and b) assigns the raw value and option value as a key/value pair in the `valueMap` object.
2. Three unit tests in `store-mutation-selectCategoricalOption.cy.js` that test a) if the value map is created when it does not yet exist, b) if the option (annotated) value is set in the value map for the raw value, and c) ensures a previously entered option value can be overwritten in the value map.
3. `annot-categorical` component and its component test in `annot-categorical.cy.js` are updated to reflect changes for the new `selectCategoricalOption` mutation