### PR TITLE
getHarmonizedPreview getter for Phase 2 Refactor

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -8,6 +8,12 @@ jobs:
     steps:
       - name: Checkout 🔍
         uses: actions/checkout@v2
+
+      - name: Set up node env
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: 16
+                  
       # Install NPM dependencies, cache them correctly
       # and run all Cypress End to End tests
       - name: Run End to End tests 🧪

--- a/components/annot-continuous-values.vue
+++ b/components/annot-continuous-values.vue
@@ -53,10 +53,9 @@
 
             ...mapGetters([
 
-                "getPreviewValues",
                 "getHarmonizedPreview",
-                "getTransformOptions",
-                "getHeuristic"
+                "getHeuristic",
+                "getTransformOptions"
             ]),
 
             validationItems() {

--- a/cypress/component/annot-continuous-values.cy.js
+++ b/cypress/component/annot-continuous-values.cy.js
@@ -15,7 +15,7 @@ const store = {
                 "column2": ["2,1", "22,1"]
             };
         },
-        getTransformHeuristics: () => (activeCategory) => {
+        getTransformationHeuristics: () => (activeCategory) => {
             return ["float", "bounded", "euro", "range", "int", "string", "isoyear"];
         }
     },

--- a/cypress/component/annot-continuous-values.cy.js
+++ b/cypress/component/annot-continuous-values.cy.js
@@ -7,12 +7,8 @@ const store = {
 
     getters: {
 
-        getHarmonizedPreview: () => (p_column, p_missingValue) => {
-            return null;
-        },
-        getHeuristic: () => (p_column) => {
-            return null;
-        },
+        getHarmonizedPreview: () => (p_column, p_missingValue) => null,
+        getHeuristic: () => (p_column) => null,
         getPreviewValues: () => (p_activeCategory) => {
 
             return {

--- a/cypress/component/annot-continuous-values.cy.js
+++ b/cypress/component/annot-continuous-values.cy.js
@@ -7,8 +7,12 @@ const store = {
 
     getters: {
 
-        getHarmonizedPreview: () => (p_column, p_missingValue) => null,
-        getHeuristic: () => (p_column) => null,
+        getHarmonizedPreview: () => (p_column, p_missingValue) => {
+            return null;
+        },
+        getHeuristic: () => (p_column) => {
+            return null;
+        },
         getPreviewValues: () => (p_activeCategory) => {
 
             return {
@@ -16,8 +20,9 @@ const store = {
                 "column2": ["2,1", "22,1"]
             };
         },
-        getTransformationHeuristics: () => (activeCategory) => {
-            return ["float", "bounded", "euro", "range", "int", "string", "isoyear"];
+        getTransformOptions: () => (activeCategory) => {
+            // return ["float", "bounded", "euro", "range", "int", "string", "isoyear"];
+            return ["float", "bounded", "euro", "range", "int", "string"];
         }
     },
 

--- a/cypress/unit/store-getter-getHarmonizedPreview.cy.js
+++ b/cypress/unit/store-getter-getHarmonizedPreview.cy.js
@@ -1,0 +1,185 @@
+import { getters } from "~/store";
+
+let store;
+let originalValue;
+
+describe("getHarmonizedPreview", () => {
+
+    beforeEach(() => {
+
+        store = {
+
+            state: {
+
+                appSetting: {
+
+                    missingValueLabel: "missing value"
+                },
+
+                dataDictionary: {
+
+                    annotated: {
+
+                        column1: {
+
+                            transformationHeuristic: ""
+                        }
+                    }
+                }
+
+            }
+        };
+    });
+
+    it.only("float transformation", () => {
+
+        console.log("Pre-setup");
+
+        // Setup
+        store.state.dataDictionary.annotated.column1.transformationHeuristic = "float";
+        originalValue = "42.6";
+
+        console.log("Pre-act");
+
+        // Act
+        const harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
+
+        console.log("Pre-assert");
+
+        // Assert
+        expect(Number.isInteger(harmonizedValue)).to.be.false;
+        expect(harmonizedValue).to.equal(42.6);
+    });
+
+    it("bounded transformation", () => {
+
+        // Setup
+        store.state.dataDictionary.annotated.column1.transformationHeuristic = "bounded";
+
+
+        // 1. Positive integer with "+" prepended
+
+        // Setup
+        originalValue = "+42";
+
+        // Act
+        let harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
+
+        // Assert
+        expect(harmonizedValue).to.equal(42);
+
+        // 2. Regular integer
+
+        // Setup
+        originalValue = "42";
+
+        // Act
+        harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
+
+        // Assert
+        expect(harmonizedValue).to.equal(42);
+
+
+        // 3. Negative integer
+
+        // Setup
+        originalValue = "-42";
+
+        // Act
+        harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
+
+        // Assert
+        expect(harmonizedValue).to.equal(-42);
+
+        // 4. Float value truncated
+
+        // Setup
+        originalValue = "42.6";
+
+        // Act
+        harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
+
+        // Assert
+        expect(harmonizedValue).to.equal(42);
+    });
+
+    it("euro transformation", () => {
+
+        // Setup
+        store.state.dataDictionary.annotated.column1.transformationHeuristic = "euro";
+        originalValue = "42,6";
+
+        // Act
+        const harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
+
+        // Assert
+        expect(Number.isInteger(harmonizedValue)).to.be.false;
+        expect(harmonizedValue).to.equal(42.6);
+    });
+
+    it("range transformation", () => {
+
+        // 1. Integer range transformation
+
+        // Setup
+        store.state.dataDictionary.annotated.column1.transformationHeuristic = "range";
+        originalValue = "42-44";
+
+        // Act
+        let harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
+
+        // Assert
+        expect(harmonizedValue).to.equal(43);
+
+        // 2. Floating point range transformation
+
+        // Setup
+        store.state.dataDictionary.annotated.column1.transformationHeuristic = "range";
+        originalValue = "42-43";
+
+        // Act
+        harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
+
+        // Assert
+        expect(harmonizedValue).to.equal(42.5);
+
+    });
+
+    it("int transformation", () => {
+
+        // Setup
+        store.state.dataDictionary.annotated.column1.transformationHeuristic = "int";
+        originalValue = "42.6";
+
+        // Act
+        const harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
+
+        // Assert
+        expect(harmonizedValue).to.equal(42);
+    });
+
+    it("string transformation", () => {
+
+        // Setup
+        store.state.dataDictionary.annotated.column1.transformationHeuristic = "string";
+
+        // Act
+        const harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
+
+        // Assert
+        expect(harmonizedValue).to.equal(store.state.appSetting.missingValueLabel);
+    });
+
+    // it("isoyear transformation", () => {
+
+    //     // Setup
+    //     store.state.dataDictionary.annotated.column1.transformationHeuristic = "isoyear";
+    //     originalValue = "22Y10M";
+
+    //     // Act
+    //     const harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
+
+    //     // Assert
+    //     expect(harmonizedValue).to.equal(32);
+    // });
+});

--- a/cypress/unit/store-getter-getHarmonizedPreview.cy.js
+++ b/cypress/unit/store-getter-getHarmonizedPreview.cy.js
@@ -31,20 +31,14 @@ describe("getHarmonizedPreview", () => {
         };
     });
 
-    it.only("float transformation", () => {
-
-        console.log("Pre-setup");
+    it("float transformation", () => {
 
         // Setup
         store.state.dataDictionary.annotated.column1.transformationHeuristic = "float";
         originalValue = "42.6";
 
-        console.log("Pre-act");
-
         // Act
         const harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
-
-        console.log("Pre-assert");
 
         // Assert
         expect(Number.isInteger(harmonizedValue)).to.be.false;

--- a/store/index.js
+++ b/store/index.js
@@ -4,6 +4,12 @@ import Vue from "vue";
 
 export const state = () => ({
 
+    appSetting: {
+
+        // The string label applied to values designated as "missing values" when the data are annotated.
+        missingValueLabel: "missing value"
+    },
+
     categoricalOptions: {
 
         "Sex": ["male", "female", "other"]
@@ -110,8 +116,11 @@ export const state = () => ({
     // transformation heuristics
     transformationHeuristics: {
 
+        // "annot-continuous-values": [
+        //     "float", "bounded", "euro", "range", "int", "string", "isoyear"
+        // ]
         "annot-continuous-values": [
-            "float", "bounded", "euro", "range", "int", "string", "isoyear"
+            "float", "bounded", "euro", "range", "int", "string"
         ]
     }
 });
@@ -159,6 +168,71 @@ export const getters = {
 
         return ( "explanation" in p_state.categories[p_category] ) ?
             p_state.categories[p_category].explanation : null;
+    },
+
+    getHarmonizedPreview: (p_state) => (p_column, p_originalValue) => {
+
+        const transformationHeuristic = p_state.dataDictionary.annotated[p_column].transformationHeuristic ?? "";
+
+        let convertedValue = "";
+
+        switch ( transformationHeuristic ) {
+
+            case "float":
+
+                convertedValue = parseFloat(p_originalValue);
+                break;
+
+            case "bounded":
+
+                convertedValue = parseInt(p_originalValue.replace("+", ""));
+                break;
+
+            case "euro":
+
+                convertedValue = parseFloat(p_originalValue.replace(",", "."));
+                break;
+
+            case "range": {
+
+                const [lower, upper] = p_originalValue.split("-").map(val => parseFloat(val.trim()));
+                convertedValue = (lower + upper) / 2;
+                break;
+            }
+
+            case "int":
+
+                convertedValue = parseInt(p_originalValue);
+                break;
+
+            case "string":
+
+                convertedValue = p_state.appSetting.missingValueLabel;
+                break;
+
+            // case "isoyear": {
+
+            //     // Returns an Object array where keys are the format(s) of the age value and values are the portion of the
+            //     // age value that matches this format (in some cases, only a substring may match, or there may be several substrings)
+            //     // If no capture group matches, return "undefined"
+            //     const regularExpressions = ['(?<isoyear>\\d+Y)?(?<isomonth>\\d+M)?'];
+            //     const ageRegex = new RegExp(regularExpressions.join("|"));
+            //     const regexHits = ageRegex.exec(p_originalValue);
+            //     const matchingKeys = Object.keys(regexHits.groups).filter(key => undefined !== regexHits.groups[key]);
+            //     const ageFormats = ( null !== regexHits ) ? Object.fromEntries(matchingKeys.map(key => [key, regexHits.groups[key]])) : "";
+
+            //     const yearValue = parseInt(ageFormats.isoyear.replace("Y", ""));
+            //     const monthValue = Object.keys(ageFormats).includes("isomonth") ? parseInt(ageFormats.isomonth.replace("M", "")) / 12 : 0;
+
+            //     convertedValue = `${yearValue + monthValue}`;
+            //     break;
+            // }
+
+            default:
+                break;
+        }
+
+        return convertedValue;
     },
 
     getHeuristic: (p_state) => (p_columnName) => {

--- a/store/index.js
+++ b/store/index.js
@@ -123,6 +123,13 @@ export const getters = {
         return p_state.categories[p_category].componentName;
     },
 
+    getCategoricalOptions: (p_state) => (p_column) => {
+
+        // Return the options for this column listed in the current (hardcoded)
+        // options for each categorical data-based category
+        return p_state.categoricalOptions[p_state.columnToCategoryMapping[p_column]] ?? [];
+    },
+
     getCategoryNames (p_state) {
 
 
@@ -158,20 +165,6 @@ export const getters = {
 
         return ( "transformationHeuristic" in p_state.dataDictionary.annotated[p_columnName] ) ?
             p_state.dataDictionary.annotated[p_columnName].transformationHeuristic : "";
-    },
-
-    getTransformationHeuristic: (p_state) => (p_category) => {
-
-        let heuristics = [];
-        switch ( p_category ) {
-
-            case "Age":
-
-                heuristics = ["float", "bounded", "euro", "range", "int", "string", "isoyear"];
-                break;
-        }
-
-        return heuristics;
     },
 
     getMappedColumns: (p_state) => (p_category) => {
@@ -237,13 +230,6 @@ export const getters = {
         }
 
         return nextPage;
-    },
-
-    getCategoricalOptions: (p_state) => (p_column) => {
-
-        // Return the options for this column listed in the current (hardcoded)
-        // options for each categorical data-based category
-        return p_state.categoricalOptions[p_state.columnToCategoryMapping[p_column]] ?? [];
     },
 
     getTransformOptions: (p_state) => (p_category) => {

--- a/store/index.js
+++ b/store/index.js
@@ -145,6 +145,20 @@ export const getters = {
             p_state.dataDictionary.annotated[p_columnName].transformationHeuristic : "";
     },
 
+    getTransformationHeuristic: (p_state) => (p_category) => {
+
+        let heuristics = [];
+        switch ( p_category ) {
+
+            case "Age":
+
+                heuristics = ["float", "bounded", "euro", "range", "int", "string", "isoyear"];
+                break;
+        }
+
+        return heuristics;
+    },
+
     getMappedColumns: (p_state) => (p_category) => {
 
         const mappedColumns = [];


### PR DESCRIPTION
This addresses #272 by implementing the following:

1. The creation of new store getter `getHarmonizedPreview` which takes a column name and a data table value and produces a transformed version of that value given the transformation heuristic assigned to the given column. Of note, for this new implementation of functionality that was contained in the previous component `annot-age-values` is that `isoyear` transformation is currently being left (commented) out so it can be more fully addressed in a more robust way in its own new issue.
2. The introduction of the `appSetting` store field as mentioned in our Miro board draft of the store refactor. Currently this only contains the `missingValueLabel` for the `'string'` transformation heuristic.
3. Tests for each different transformation heuristic have been added in `store-getter-getHarmonizedPreview.cy.js`
4. Correlating adjustments have been made to the `annot-continuous-values` component and its test file `annot-continuous-values.cy.js`