### PR TITLE
Feature for Phase 2 Refactor: Transform Heuristics for continuous values are now selectable by column

### DIFF
--- a/components/annot-continuous-values.vue
+++ b/components/annot-continuous-values.vue
@@ -99,15 +99,12 @@
 
                 // 2. Create items for the table consisting of objects containing column name, raw and transformed values
                 const tableItems = [];
-                Object.keys(uniqueValuesByColumn).forEach(columnName => {
+                uniqueValuesByColumn[p_columnName].forEach(value => {
 
-                    return uniqueValuesByColumn[columnName].forEach(value => {
+                    tableItems.push({
 
-                        tableItems.push({
-
-                            preview: this.getHarmonizedPreview(p_columnName, value),
-                            rawValue: value
-                        });
+                        preview: this.getHarmonizedPreview(p_columnName, value),
+                        rawValue: value
                     });
                 });
 

--- a/cypress/component/annot-continuous-values.cy.js
+++ b/cypress/component/annot-continuous-values.cy.js
@@ -146,4 +146,95 @@ describe("Continuous values component", () => {
           .find("td").eq(0)
           .should("contain", "22.1");
     });
+
+    it("Displays two or more columns in separate tabs with different data", () => {
+
+        // Setup
+        store.state.dataDictionary.annotated["column2"] = { transformationHeuristic: "" };
+        store.getters.getMappedColumns = () => (p_activeCategory) => {
+
+            return ["column1", "column2"];
+        };
+        store.getters.getUniqueValues = () => (p_activeCategory) => {
+
+            return {
+
+                column1: ["2,1", "22,1"],
+                column2: ["4,1", "44,1"]
+            };
+        };
+
+        // Act
+        cy.mount(annotContinuousValues, {
+
+            computed: store.getters,
+            mocks: { $store: store },
+            plugins: ["vue-select"],
+            propsData: props
+        });
+
+        // Assert
+        cy.get("[data-cy='dataTable-column1']").should("exist");
+        cy.get("[data-cy='dataTable-column1'] tr").eq(1)
+          .find("td").eq(1)
+          .should("contain", "2,1");
+        cy.get("[data-cy='dataTable-column1'] tr").eq(2)
+          .find("td").eq(1)
+          .should("contain", "22,1");
+        cy.get("[data-cy='dataTable-column2']").should("exist");
+        cy.get("[data-cy='dataTable-column2'] tr").eq(1)
+          .find("td").eq(1)
+          .should("contain", "4,1");
+        cy.get("[data-cy='dataTable-column2'] tr").eq(2)
+          .find("td").eq(1)
+          .should("contain", "44,1");
+    });
+
+    it("Able to transform two or more columns", () => {
+
+        // Setup
+        store.state.dataDictionary.annotated["column2"] = { transformationHeuristic: "" };
+        store.getters.getMappedColumns = () => (p_activeCategory) => {
+
+            return ["column1", "column2"];
+        };
+        store.getters.getUniqueValues = () => (p_activeCategory) => {
+
+            return {
+
+                column1: ["2,1", "22,1"],
+                column2: ["4,1", "44,1"]
+            };
+        };
+        cy.mount(annotContinuousValues, {
+
+            computed: store.getters,
+            mocks: { $store: store },
+            plugins: ["vue-select"],
+            propsData: props
+        });
+
+        // Act
+        cy.get("[data-cy='selectTransform_column1']").click().contains("euro").click();
+
+        // Assert - With euro transformation selected, preview values should have ',' replaced with '.'
+        cy.get("[data-cy='dataTable-column1'] tr").eq(1)
+          .find("td").eq(0)
+          .should("contain", "2.1");
+        cy.get("[data-cy='dataTable-column1'] tr").eq(2)
+          .find("td").eq(0)
+          .should("contain", "22.1");
+
+        // Act
+        cy.get(".nav-link").contains("column2").click();
+        cy.get("[data-cy='selectTransform_column2']").click().contains("euro").click();
+
+        // Assert - With euro transformation selected, preview values should have ',' replaced with '.'
+        cy.get("[data-cy='dataTable-column2'] tr").eq(1)
+          .find("td").eq(0)
+          .should("contain", "4.1");
+        cy.get("[data-cy='dataTable-column2'] tr").eq(2)
+          .find("td").eq(0)
+          .should("contain", "44.1");
+    });
 });

--- a/store/index.js
+++ b/store/index.js
@@ -4,6 +4,12 @@ import Vue from "vue";
 
 export const state = () => ({
 
+    appSetting: {
+
+        // The string label applied to values designated as "missing values" when the data are annotated.
+        missingValueLabel: "missing value"
+    },
+
     categoricalOptions: {
 
         "Sex": ["male", "female", "other"]
@@ -110,8 +116,11 @@ export const state = () => ({
     // transformation heuristics
     transformationHeuristics: {
 
+        // "annot-continuous-values": [
+        //     "", "float", "bounded", "euro", "range", "int", "string", "isoyear"
+        // ]
         "annot-continuous-values": [
-            "float", "bounded", "euro", "range", "int", "string", "isoyear"
+            "", "float", "bounded", "euro", "range", "int", "string"
         ]
     }
 });
@@ -121,6 +130,13 @@ export const getters = {
     getAnnotationComponent: (p_state) => (p_category) => {
 
         return p_state.categories[p_category].componentName;
+    },
+
+    getCategoricalOptions: (p_state) => (p_column) => {
+
+        // Return the options for this column listed in the current (hardcoded)
+        // options for each categorical data-based category
+        return p_state.categoricalOptions[p_state.columnToCategoryMapping[p_column]] ?? [];
     },
 
     getCategoryNames (p_state) {
@@ -152,6 +168,71 @@ export const getters = {
 
         return ( "explanation" in p_state.categories[p_category] ) ?
             p_state.categories[p_category].explanation : null;
+    },
+
+    getHarmonizedPreview: (p_state) => (p_column, p_originalValue) => {
+
+        const transformationHeuristic = p_state.dataDictionary.annotated[p_column].transformationHeuristic ?? "";
+
+        let convertedValue = "";
+
+        switch ( transformationHeuristic ) {
+
+            case "float":
+
+                convertedValue = parseFloat(p_originalValue);
+                break;
+
+            case "bounded":
+
+                convertedValue = parseInt(p_originalValue.replace("+", ""));
+                break;
+
+            case "euro":
+
+                convertedValue = parseFloat(p_originalValue.replace(",", "."));
+                break;
+
+            case "range": {
+
+                const [lower, upper] = p_originalValue.split("-").map(val => parseFloat(val.trim()));
+                convertedValue = (lower + upper) / 2;
+                break;
+            }
+
+            case "int":
+
+                convertedValue = parseInt(p_originalValue);
+                break;
+
+            case "string":
+
+                convertedValue = p_state.appSetting.missingValueLabel;
+                break;
+
+            // case "isoyear": {
+
+            //     // Returns an Object array where keys are the format(s) of the age value and values are the portion of the
+            //     // age value that matches this format (in some cases, only a substring may match, or there may be several substrings)
+            //     // If no capture group matches, return "undefined"
+            //     const regularExpressions = ['(?<isoyear>\\d+Y)?(?<isomonth>\\d+M)?'];
+            //     const ageRegex = new RegExp(regularExpressions.join("|"));
+            //     const regexHits = ageRegex.exec(p_originalValue);
+            //     const matchingKeys = Object.keys(regexHits.groups).filter(key => undefined !== regexHits.groups[key]);
+            //     const ageFormats = ( null !== regexHits ) ? Object.fromEntries(matchingKeys.map(key => [key, regexHits.groups[key]])) : "";
+
+            //     const yearValue = parseInt(ageFormats.isoyear.replace("Y", ""));
+            //     const monthValue = Object.keys(ageFormats).includes("isomonth") ? parseInt(ageFormats.isomonth.replace("M", "")) / 12 : 0;
+
+            //     convertedValue = `${yearValue + monthValue}`;
+            //     break;
+            // }
+
+            default:
+                break;
+        }
+
+        return convertedValue;
     },
 
     getHeuristic: (p_state) => (p_columnName) => {
@@ -223,13 +304,6 @@ export const getters = {
         }
 
         return nextPage;
-    },
-
-    getCategoricalOptions: (p_state) => (p_column) => {
-
-        // Return the options for this column listed in the current (hardcoded)
-        // options for each categorical data-based category
-        return p_state.categoricalOptions[p_state.columnToCategoryMapping[p_column]] ?? [];
     },
 
     getTransformOptions: (p_state) => (p_category) => {
@@ -486,6 +560,8 @@ export const mutations = {
     },
 
     setHeuristic(p_state, { column, heuristic }) {
+
+        console.log("Store setHeuristic");
 
         // Set a new transformation heuristic for this column
         Vue.set(p_state.dataDictionary.annotated[column], "transformationHeuristic", heuristic);

--- a/store/index.js
+++ b/store/index.js
@@ -561,8 +561,6 @@ export const mutations = {
 
     setHeuristic(p_state, { column, heuristic }) {
 
-        console.log("Store setHeuristic");
-
         // Set a new transformation heuristic for this column
         Vue.set(p_state.dataDictionary.annotated[column], "transformationHeuristic", heuristic);
     }


### PR DESCRIPTION
This PR implements #336.

1. The `annot-continuous-values` component (that is used on the annotation page tab, currently exclusively for 'Age'-categorized columns) now features one tab per column
2. Each tab lists the data for that column with an original value and preview value column
3. Each contains a dropdown featuring all of the app's transformation heuristics for continuous values - including a default blank with which no transformation has yet taken place
4. Unit tests in `annot-continuous-values.cy.js` have been reworked and extended for the new feature

NOTE: @rmanaem There was something happening in the testing that I could not explain. The reason that the `store` variable is initialized each time in the `beforeEach` function is because its function definitions in `store.getters` were seemingly being wiped by (at least) the first individual test. This is difficult to debug because `JSON.stringify` will not display functions defined on an object. Not sure this is necessarily worth our time to looking into, but if you can see something that might have caused that behavior please point it out.