### PR TITLE
Refactor: handle controlled terms as objects

### DIFF
--- a/components/annot-categorical.vue
+++ b/components/annot-categorical.vue
@@ -20,10 +20,15 @@
                         <!-- Bootstrap-Vue doesn't have a great option here so I am using https://vue-select.org/ -->
                         <!-- NOTE: We use the $event statement to add the row data to the payload of the @input
                             event without replacing the original event payload -->
+                        <!-- NOTE: We're using the "reduce" option for vue-select so that we can pass around the
+                            term.identifier parameter, but still display the term.label parameter to the user.
+                            See: https://vue-select.org/guide/values.html#transforming-selections -->
 
                         <v-select
                             :data-cy="'categoricalSelector' + '_' + row.index"
                             :value="getSelectedOption(row.index)"
+                            :label="label"
+                            :reduce="term => term.identifier"
                             @input="selectCategoricalOption($event, row.item['columnName'], row.item['rawValue'])"
                             :options="getCategoricalOptions(row.item['columnName'])" />
                     </template>

--- a/cypress/component/annot-categorical.cy.js
+++ b/cypress/component/annot-categorical.cy.js
@@ -10,12 +10,17 @@ const store = {
 
         getCategoricalOptions: () => (p_column) => {
 
-            return ["option_0", "option_1", "option_2", "option_3"];
+            return [
+                { label: "option_0", identifier: "https://example.org/option_0"},
+                { label: "option_1", identifier: "https://example.org/option_1"},
+                { label: "option_2", identifier: "https://example.org/option_2"},
+                { label: "option_3", identifier: "https://example.org/option_3"}
+            ];
         },
 
         getSelectedOption: () => (p_rowIndex) => {
 
-            return "option_" + p_rowIndex;
+            return "https://example.org/option_" + p_rowIndex;
         },
 
         getUniqueValues: () => (p_activeCategory) => {
@@ -85,7 +90,7 @@ describe("Categorical annotation", () => {
         cy.get("[data-cy='categoricalSelector_0']").click().contains("option_2").click();
 
         // Assert
-        cy.get("@commitSpy").should("have.been.calledOnceWith", "selectCategoricalOption", "option_2", "column1", "PD");
+        cy.get("@commitSpy").should("have.been.calledOnceWith", "selectCategoricalOption", "https://example.org/option_2", "column1", "PD");
     });
 
     it("Displays the preset mapping in the dropdown", () => {

--- a/cypress/component/annot-categorical.cy.js
+++ b/cypress/component/annot-categorical.cy.js
@@ -126,4 +126,15 @@ describe("Categorical annotation", () => {
         // Assert
         cy.get("@commitSpy").should("have.been.calledOnceWith", "changeMissingStatus", "column1", "HC", true);
     });
+
+    it("Can deal with an empty options array without crashing", () => {
+
+        // Setup
+        cy.mount(annotCategorical, {
+            computed: Object.assign(store.getters, { getCategoricalOptions: () => (p_column) => [],
+                getSelectedOption: () => (p_rowIndex) => null }),
+            mocks: { $store: store },
+            propsData: props
+        });
+    });
 });

--- a/cypress/unit/store-getter-getCategoricalOptions.cy.js
+++ b/cypress/unit/store-getter-getCategoricalOptions.cy.js
@@ -8,7 +8,10 @@ let store = {
 
         categoricalOptions: {
 
-            "category1": ["option1", "option2"]
+            "category1": [
+                { label: "option_0", identifier: "https://example.org/option_0"},
+                { label: "option_1", identifier: "https://example.org/option_1"}
+            ]
         },
 
         columnToCategoryMapping: {
@@ -26,7 +29,10 @@ describe("getCategoricalOptions", () => {
         const options = store.getters.getCategoricalOptions(store.state)("column1");
 
         // Assert
-        expect(options).to.deep.equal(["option1", "option2"]);
+        expect(options).to.deep.equal([
+            { label: "option_0", identifier: "https://example.org/option_0"},
+            { label: "option_1", identifier: "https://example.org/option_1"}
+        ]);
     });
 
     it("Returns empty list for a categorical column that has no options in its data dictionary entry", () => {

--- a/cypress/unit/store-mutation-selectCategoricalOption.cy.js
+++ b/cypress/unit/store-mutation-selectCategoricalOption.cy.js
@@ -24,7 +24,7 @@ describe("selectCategoricalOption mutation", () => {
     it("Makes sure a value map is created for a column in the data dictionary", () => {
 
         // Act
-        mutations.selectCategoricalOption(store.state, "female", "column1", "F");
+        mutations.selectCategoricalOption(store.state, "https://example.org/female", "column1", "F");
 
         // Assert
         expect(store.state.dataDictionary.annotated.column1.valueMap).to.exist;
@@ -33,19 +33,19 @@ describe("selectCategoricalOption mutation", () => {
     it("Makes sure an annotated value is set in the value map", () => {
 
         // Act
-        mutations.selectCategoricalOption(store.state, "female", "column1", "F");
+        mutations.selectCategoricalOption(store.state, "https://example.org/female", "column1", "F");
 
         // Assert
-        expect(store.state.dataDictionary.annotated.column1.valueMap["F"]).to.equal("female");
+        expect(store.state.dataDictionary.annotated.column1.valueMap["F"]).to.equal("https://example.org/female");
     });
 
     it("Makes sure a value in the value map can be overwritten", () => {
 
         // Act
-        mutations.selectCategoricalOption(store.state, "female", "column1", "F");
-        mutations.selectCategoricalOption(store.state, "female", "column1", "Female");
+        mutations.selectCategoricalOption(store.state, "https://example.org/female", "column1", "F");
+        mutations.selectCategoricalOption(store.state, "https://example.org/male", "column1", "F");
 
         // Assert
-        expect(store.state.dataDictionary.annotated.column1.valueMap["Female"]).to.equal("female");
+        expect(store.state.dataDictionary.annotated.column1.valueMap["F"]).to.equal("https://example.org/male");
     });
 });

--- a/store/index.js
+++ b/store/index.js
@@ -12,7 +12,11 @@ export const state = () => ({
 
     categoricalOptions: {
 
-        "Sex": ["male", "female", "other"]
+        "Sex": [
+            {label: "male", identifier: "bids:male"},
+            {label: "female", identifier: "bids:female"},
+            {label: "other", identifier: "bids:other"}
+        ]
     },
 
     categories: {


### PR DESCRIPTION
Closes #371

- controlled terms are now handled as objects with `{label: "human readable label", identifier: "https://example.org/vocab/termID"}`
- the categorical annotation component and all involved tests are updated. This mostly meant changing the way vue-select handles data to objects. See: https://vue-select.org/guide/values.html#transforming-selections
- the hard-coded controlled terms in the store (for now only "sex") have been updated to correspond to this format


Overall the changes are limited, because the code can mostly just handle terms as objects already.

Two things to note:
1. Right now, we still store only a string literal in the valueMapping part of the dataDictionary, but now we store the identifier and not the label. In the future we might store the complete term object if we decide that it is necessary
2. I updated the third unit test for `selectCategoricalOption` to overwrite the stored value as described in the test


Note: 