### PR TITLE
Phase 2 Store Refactor - Integration Part 1 - Annotation page access, tabs refactor, column-category unlinking

### DIFF
--- a/components/annot-categorical.vue
+++ b/components/annot-categorical.vue
@@ -21,17 +21,18 @@
                         <!-- NOTE: We use the $event statement to add the row data to the payload of the @input
                             event without replacing the original event payload -->
 
+                        <!-- :value="getSelectedOption(row.index)" -->
                         <v-select
                             :data-cy="'categoricalSelector' + '_' + row.index"
-                            :value="getSelectedOption(row.index)"
-                            @input="selectCategoricalOption($event, row.item['columnName'], row.item['rawValue'])"
+
+                            @input="selectCategoricalOption({optionValue: $event, columnName: row.item['columnName'], rawValue: row.item['rawValue']})"
                             :options="getCategoricalOptions(row.item['columnName'])" />
                     </template>
                     <template #cell(missingValue)="row">
                         <b-button
                             :data-cy="'missingValueButton_' + row.index"
                             variant="danger"
-                            @click="changeMissingStatus(row.item['columnName'], row.item['rawValue'], true)">
+                            @click="changeMissingStatus({column: row.item['columnName'], value: row.item['rawValue'], markAsMissing: true})">
                             {{ uiText.missingValueButton }}
                         </b-button>
                     </template>
@@ -110,6 +111,7 @@
                     for ( const uniqueValue of uniqueValuesMap[columnName]) {
 
                         tableData.push({
+
                             columnName: columnName,
                             description: this.getValueDescription(columnName, uniqueValue),
                             rawValue: uniqueValue

--- a/components/annot-continuous-values.vue
+++ b/components/annot-continuous-values.vue
@@ -30,7 +30,7 @@
                                 :data-cy="'selectTransform_' + columnName"
                                 :options="getTransformOptions(activeCategory)"
                                 :value="getHeuristic(columnName)"
-                                @input="commitHeuristic(columnName, $event)" />
+                                @input="setHeuristic({ column: columnName, heuristic: $event })" />
                         </b-col>
 
                     </b-row>
@@ -109,14 +109,6 @@
                 });
 
                 return tableItems;
-            },
-
-            commitHeuristic(p_column, p_heuristic) {
-
-                // TODO: With the addition of ability to set heuristic for
-                // individual columns, 'activeCategory' below will be replaced
-                // with the appropriate column name
-                this.setHeuristic({ column: p_column, heuristic: p_heuristic });
             }
         }
     };

--- a/components/annot-tab.vue
+++ b/components/annot-tab.vue
@@ -16,7 +16,6 @@
             :is="getAnnotationComponent(activeCategory)"
             :data-cy="(getAnnotationComponent(activeCategory) + '-' + activeCategory)"
             :active-category="activeCategory"
-            :id-field="idField"
             :title="('annotate_' + activeCategory)" />
 
     </div>

--- a/components/annot-tab.vue
+++ b/components/annot-tab.vue
@@ -31,11 +31,14 @@
     export default {
 
         props: {
+
             activeCategory: { type: String, required: true }
         },
 
         computed: {
+
             ...mapGetters([
+
                 "getAnnotationComponent"
             ])
         }

--- a/cypress/component/annot-continuous-values.cy.js
+++ b/cypress/component/annot-continuous-values.cy.js
@@ -58,7 +58,7 @@ describe("Continuous values component", () => {
 
                 // NOTE: changeMissingStatus reflects a future 'mark as missing' feature
                 // for the continous value component
-                changeMissingStatus: () => (p_columnName, p_rawValue, p_markAsMissing) => {},
+                changeMissingStatus: () => ({ column, value, markAsMissing}) => {},
                 setHeuristic: ({ column, heuristic }) => {
 
                     store.state.dataDictionary.annotated[column].transformationHeuristic = heuristic;

--- a/cypress/e2e/page/categorization-pagetests.cy.js
+++ b/cypress/e2e/page/categorization-pagetests.cy.js
@@ -68,7 +68,7 @@ describe("Tests on categorization page ui via programmatic state loading and sto
                     // 2. Categorize first subject id column in table as 'Subject ID'
                     cy.categorizeColumn("Subject ID", p_dataset["category_columns"]["Subject ID"][0]);
 
-                    // 3. Assert that annotation nav and next page button are enabled
+                    // 3. Assert that annotation nav and next page button are disabled
                     cy.assertNextPageAccess("annotation", false);
                 }
             });

--- a/cypress/e2e/page/categorization-pagetests.cy.js
+++ b/cypress/e2e/page/categorization-pagetests.cy.js
@@ -69,7 +69,7 @@ describe("Tests on categorization page ui via programmatic state loading and sto
                     cy.categorizeColumn("Subject ID", p_dataset["category_columns"]["Subject ID"][0]);
 
                     // 3. Assert that annotation nav and next page button are enabled
-                    cy.assertNextPageAccess("annotation", true);
+                    cy.assertNextPageAccess("annotation", false);
                 }
             });
 

--- a/cypress/unit/store-getter-getMappedCategories.cy.js
+++ b/cypress/unit/store-getter-getMappedCategories.cy.js
@@ -1,0 +1,29 @@
+import { getters } from "~/store";
+
+const store = {
+
+    state: {
+
+        columnToCategoryMapping: {
+
+            column1: "category1",
+            column2: "category2",
+            column3: "category1"
+        }
+    }
+};
+
+describe("getMappedCategories", () => {
+
+    it("Get list of unique categories", () => {
+
+        // Assert
+        expect(getters.getMappedCategories(store.state)()).to.deep.equal(["category1", "category2"]);
+    });
+
+    it("Get list of unique categories, skipping one", () => {
+
+        // Assert
+        expect(getters.getMappedCategories(store.state)(["category1"])).to.deep.equal(["category2"]);
+    });
+});

--- a/cypress/unit/store-getter-isPageAccessible.cy.js
+++ b/cypress/unit/store-getter-isPageAccessible.cy.js
@@ -47,6 +47,7 @@ describe("isPageAccessible", () => {
 
         // Setup
         let nextPage = "annotation";
+        state.columnToCategoryMapping["column2Name"] = "Sex";
 
         // Assert
         expect(getters.isPageAccessible(state)(nextPage)).to.be.true;

--- a/cypress/unit/store-mutation-selectCategoricalOption.cy.js
+++ b/cypress/unit/store-mutation-selectCategoricalOption.cy.js
@@ -24,7 +24,11 @@ describe("selectCategoricalOption mutation", () => {
     it("Makes sure a value map is created for a column in the data dictionary", () => {
 
         // Act
-        mutations.selectCategoricalOption(store.state, "female", "column1", "F");
+        mutations.selectCategoricalOption(store.state, {
+            optionValue: "female",
+            columnName: "column1",
+            rawValue: "F"
+        });
 
         // Assert
         expect(store.state.dataDictionary.annotated.column1.valueMap).to.exist;
@@ -33,7 +37,11 @@ describe("selectCategoricalOption mutation", () => {
     it("Makes sure an annotated value is set in the value map", () => {
 
         // Act
-        mutations.selectCategoricalOption(store.state, "female", "column1", "F");
+        mutations.selectCategoricalOption(store.state, {
+            optionValue: "female",
+            columnName: "column1",
+            rawValue: "F"
+        });
 
         // Assert
         expect(store.state.dataDictionary.annotated.column1.valueMap["F"]).to.equal("female");
@@ -42,8 +50,16 @@ describe("selectCategoricalOption mutation", () => {
     it("Makes sure a value in the value map can be overwritten", () => {
 
         // Act
-        mutations.selectCategoricalOption(store.state, "female", "column1", "F");
-        mutations.selectCategoricalOption(store.state, "female", "column1", "Female");
+        mutations.selectCategoricalOption(store.state, {
+            optionValue: "female",
+            columnName: "column1",
+            rawValue: "F"
+        });
+        mutations.selectCategoricalOption(store.state, {
+            optionValue: "female",
+            columnName: "column1",
+            rawValue: "Female"
+        });
 
         // Assert
         expect(store.state.dataDictionary.annotated.column1.valueMap["Female"]).to.equal("female");

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -28,15 +28,14 @@
                 v-model="tabNavTitle">
 
                 <b-tab
-                    v-for="details in annotationDetails"
-                    :key="details.id"
-                    :title="tabTitle(details)"
-                    :title-link-class="tabStyle(details)">
+                    v-for="(category, index) in getMappedCategories"
+                    :key="index"
+                    :title="category"
+                    :title-link-class="['annotation-tab-nav', colorInfo.categoryClasses[category]]">
 
                     <b-card-text>
                         <annot-tab
-                            :details="details"
-                            :title="tabTitle(details)"
+                            :active-category="category"
                             @remove:column="unlinkColumnFromCategory($event)"
                             @remove:missingValue="removeMissingValue($event)"
                             @update:dataTable="setAnnotatedDataTable($event.transformedTable)"
@@ -83,16 +82,13 @@
 
             ...mapGetters([
 
-                "getGroupOfTool",
-                "isToolGrouped"
+                "getMappedCategories"
             ]),
 
             ...mapState([
 
-                "annotationDetails",
-                "categoryClasses",
-                "missingColumnValues",
-                "toolGroups"
+                "colorInfo",
+                "missingColumnValues"
             ])
         },
 
@@ -105,7 +101,6 @@
 
             ...mapMutations([
 
-                "deleteToolFromGroup",
                 "removeColumnCategorization",
                 "setAnnotatedDataTable",
                 "setMissingColumnValues"
@@ -165,29 +160,6 @@
 
                 // 2. Save the new missing value list for this column to the store
                 this.setMissingColumnValues(missingValuesList);
-            },
-
-            tabStyle(p_details) {
-
-                // NOTE: The 'title-link-class' attribute for b-tab expects a single or list of classes
-
-                // Style assessment tool group tabs like assessment tools
-                if ( Object.hasOwn(p_details, "groupName") ) {
-
-                    return ["annotation-tab-nav", this.categoryClasses["Assessment Tool"]];
-                }
-
-                // Else, style the tab based on the detail's category
-                return ["annotation-tab-nav", this.categoryClasses[p_details.category]];
-            },
-
-            tabTitle(p_details) {
-
-                // Return the annotation detail's tool group name if it exists,
-                // otherwise just the detail's category
-                return ( Object.hasOwn(p_details, "groupName") ) ?
-                    p_details.groupName : p_details.category;
-
             },
 
             unlinkColumnFromCategory(p_event) {

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -18,6 +18,7 @@
             See: https://nuxtjs.org/docs/features/nuxt-components/#the-client-only-component
         -->
         <client-only>
+
             <!-- This gives us built-in keyboard navigation! -->
             <b-tabs
                 card
@@ -28,19 +29,20 @@
                 v-model="tabNavTitle">
 
                 <b-tab
-                    v-for="(category, index) in getMappedCategories"
+                    v-for="(category, index) in getMappedCategories(categorySkipList)"
                     :key="index"
                     :title="category"
                     :title-link-class="['annotation-tab-nav', colorInfo.categoryClasses[category]]">
 
                     <b-card-text>
-                        <annot-tab
+                        <!-- <annot-tab
                             :active-category="category"
                             @remove:column="unlinkColumnFromCategory($event)"
                             @remove:missingValue="removeMissingValue($event)"
                             @update:dataTable="setAnnotatedDataTable($event.transformedTable)"
                             @update:missingColumnValues="setMissingColumnValues($event)"
-                            @update:missingValue="addMissingValue($event)" />
+                            @update:missingValue="addMissingValue($event)" /> -->
+                        <annot-tab :active-category="category" />
                     </b-card-text>
 
                 </b-tab>
@@ -54,17 +56,8 @@
 
 <script>
 
-    // Allows for reference to store actions (index.js)
-    import { mapActions } from "vuex";
-
-    // Allows for reference to store data by creating simple, implicit getters
-    import { mapGetters } from "vuex";
-
-    // Allows for direct mutations of store data
-    import { mapMutations } from "vuex";
-
-    // Fields listed in mapState below can be found in the store (index.js)
-    import { mapState } from "vuex";
+    // Allows for reference to store actions, getters, mutations, and state fields (index.js)
+    import { mapActions, mapGetters, mapMutations, mapState } from "vuex";
 
     export default {
 
@@ -74,6 +67,7 @@
 
             return {
 
+                categorySkipList: ["Subject ID"],
                 tabNavTitle: 0
             };
         },
@@ -87,8 +81,8 @@
 
             ...mapState([
 
-                "colorInfo",
-                "missingColumnValues"
+                "colorInfo"
+                // "missingColumnValues"
             ])
         },
 
@@ -96,17 +90,17 @@
 
             ...mapActions([
 
-                "revertColumnToOriginal"
+                // "revertColumnToOriginal"
             ]),
 
             ...mapMutations([
 
-                "removeColumnCategorization",
-                "setAnnotatedDataTable",
-                "setMissingColumnValues"
-            ]),
+                // "removeColumnCategorization",
+                // "setAnnotatedDataTable",
+                // "setMissingColumnValues"
+            ])
 
-            addMissingValue(p_event) {
+            /* addMissingValue(p_event) {
 
                 // This method expects an event object with a `column` and a `value` key.
                 // It will merge the new missing value with the existing missing value array for
@@ -189,7 +183,7 @@
                         }
                     }
                 }
-            }
+            }*/
         }
     };
 

--- a/store/index.js
+++ b/store/index.js
@@ -343,7 +343,8 @@ export const getters = {
 
                     // a. Check to see if this value is marked as 'missing' for this column
                     let value = p_state.dataTable[index][columnName];
-                    if ( !p_state.dataDictionary.annotated[columnName].missingValues.includes(value) ) {
+                    if ( "missingValues" in p_state.dataDictionary.annotated[columnName] &&
+                         !p_state.dataDictionary?.annotated[columnName]?.missingValues.includes(value) ) {
 
                         uniqueValues[columnName].add(value);
                     }

--- a/store/index.js
+++ b/store/index.js
@@ -241,6 +241,12 @@ export const getters = {
             p_state.dataDictionary.annotated[p_columnName].transformationHeuristic : "";
     },
 
+    getMappedCategories: (p_state) => (p_skipCategories=[]) => {
+
+        // Return list of all categories linked to columns (filtered by given categories to skip)
+        return [...new Set(Object.values(p_state.columnToCategoryMapping).filter(x => !p_skipCategories.has(x)))];
+    },
+
     getMappedColumns: (p_state) => (p_category) => {
 
         const mappedColumns = [];

--- a/store/index.js
+++ b/store/index.js
@@ -399,16 +399,22 @@ export const getters = {
 
                 // 1. Determine if at least one column has been linked to a category
                 const categorizationStatus = Object.values(p_state.columnToCategoryMapping)
-                                                   .some(category =>  null !== category );
+                                                   .some(category => null !== category );
 
                 // 2. Make sure one (and only one) column has been categorized as 'Subject ID'
                 const singleSubjectIDColumn = ( 1 === Object.values(p_state.columnToCategoryMapping)
                                                             .filter(category => "Subject ID" === category)
                                                             .length );
 
+                const notOnlySubjectIDCategorized = ( Object.values(p_state.columnToCategoryMapping)
+                                                            .filter(category => "Subject ID" !== category &&
+                                                                    null !== category)
+                                                            .length >= 1 );
+
                 // Annotation page is only accessible if at least one column has
                 // been categorized and if one (and only one) column has been categorized as 'Subject ID'
-                pageAccessible = categorizationStatus && singleSubjectIDColumn;
+                // and if at least one category other than Subject ID has been categorized
+                pageAccessible = categorizationStatus && singleSubjectIDColumn && notOnlySubjectIDCategorized;
 
                 break;
             }

--- a/store/index.js
+++ b/store/index.js
@@ -480,12 +480,22 @@ export const mutations = {
 
         if ( markAsMissing ) {
 
+            // 1. Create missing value list if it does not yet exist
+            // NOTE: The idea here is to only have missing value lists for columns as needed
+            // And this will be reflected in the data dictionary output from the download page
+            if ( !("missingValues" in p_state.dataDictionary.annotated[column]) ) {
+
+                p_state.dataDictionary.annotated[column].missingValues = [];
+            }
+
+            // 2. Only add unique values to the missing value list
             if ( !p_state.dataDictionary.annotated[column].missingValues.includes(value) ) {
 
                 p_state.dataDictionary.annotated[column].missingValues.push(value);
             }
         } else {
 
+            // 1. Remove value from the missing value list
             p_state.dataDictionary.annotated[column].missingValues.splice(
                 p_state.dataDictionary.annotated[column].missingValues.indexOf(value), 1);
         }

--- a/store/index.js
+++ b/store/index.js
@@ -405,24 +405,21 @@ export const getters = {
 
             case "annotation": {
 
-                // 1. Determine if at least one column has been linked to a category
-                const categorizationStatus = Object.values(p_state.columnToCategoryMapping)
-                                                   .some(category => null !== category );
-
-                // 2. Make sure one (and only one) column has been categorized as 'Subject ID'
+                // 1. Make sure one (and only one) column has been categorized as 'Subject ID'
                 const singleSubjectIDColumn = ( 1 === Object.values(p_state.columnToCategoryMapping)
                                                             .filter(category => "Subject ID" === category)
                                                             .length );
 
+                // 2. Make sure at least one other category other than 'Subject ID' has been linked to a column
                 const notOnlySubjectIDCategorized = ( Object.values(p_state.columnToCategoryMapping)
                                                             .filter(category => "Subject ID" !== category &&
                                                                     null !== category)
                                                             .length >= 1 );
 
-                // Annotation page is only accessible if at least one column has
-                // been categorized and if one (and only one) column has been categorized as 'Subject ID'
-                // and if at least one category other than Subject ID has been categorized
-                pageAccessible = categorizationStatus && singleSubjectIDColumn && notOnlySubjectIDCategorized;
+                // Annotation page is only accessible if one (and only one)
+                // column has been categorized as 'Subject ID' and if at least
+                // one category other than Subject ID has been categorized
+                pageAccessible = singleSubjectIDColumn && notOnlySubjectIDCategorized;
 
                 break;
             }

--- a/store/index.js
+++ b/store/index.js
@@ -241,7 +241,7 @@ export const getters = {
             p_state.dataDictionary.annotated[p_columnName].transformationHeuristic : "";
     },
 
-    getMappedCategories: (p_state) => (p_categorySkipList) => {
+    getMappedCategories: (p_state) => (p_categorySkipList=[]) => {
 
         // 1. Remove unmapped (null) columns and skipped categories
         const currentCategories = Object.values(p_state.columnToCategoryMapping)

--- a/store/index.js
+++ b/store/index.js
@@ -343,8 +343,11 @@ export const getters = {
 
                     // a. Check to see if this value is marked as 'missing' for this column
                     let value = p_state.dataTable[index][columnName];
-                    if ( "missingValues" in p_state.dataDictionary.annotated[columnName] &&
-                         !p_state.dataDictionary?.annotated[columnName]?.missingValues.includes(value) ) {
+
+                    if ( !("missingValues" in p_state.dataDictionary.annotated[columnName]) ) {
+
+                        uniqueValues[columnName].add(value);
+                    } else if ( !p_state.dataDictionary?.annotated[columnName].missingValues.includes(value) ) {
 
                         uniqueValues[columnName].add(value);
                     }
@@ -464,12 +467,13 @@ export const mutations = {
     alterColumnCategoryMapping(p_state, { category, column }) {
 
         if (p_state.columnToCategoryMapping[column] === category) {
+
             p_state.columnToCategoryMapping[column] = null;
         }
         else {
+
             p_state.columnToCategoryMapping[column] = category;
         }
-
     },
 
     changeMissingStatus(p_state, { column, value, markAsMissing }) {
@@ -509,16 +513,16 @@ export const mutations = {
         p_state.dataDictionary.annotated = JSON.parse(JSON.stringify(p_state.dataDictionary.userProvided));
     },
 
-    selectCategoricalOption(p_state, p_optionValue, p_columnName, p_rawValue) {
+    selectCategoricalOption(p_state, { optionValue, columnName, rawValue }) {
 
         // 0. Create an categorical value map for this column, if it does not yet exist
-        if ( !("valueMap" in p_state.dataDictionary.annotated[p_columnName]) ) {
+        if ( !("valueMap" in p_state.dataDictionary.annotated[columnName]) ) {
 
-            p_state.dataDictionary.annotated[p_columnName].valueMap = {};
+            p_state.dataDictionary.annotated[columnName].valueMap = {};
         }
 
         // 1. Assign the option value to a raw value for this column
-        p_state.dataDictionary.annotated[p_columnName].valueMap[p_rawValue] = p_optionValue;
+        p_state.dataDictionary.annotated[columnName].valueMap[rawValue] = optionValue;
     },
 
     setCurrentPage(p_state, p_pageName) {
@@ -556,23 +560,29 @@ export const mutations = {
         let dataTable = [];
 
         for ( const [rowIndex, row] of p_dataTable.slice(1).entries() ) {
+
             // If the row is empty, we don't want it in our dataTable
             if ( "" === row.join("").trim() ) {
+
                 continue;
             } else if ( row.length < columnNames.length ) {
+
                 console.warn("WARNING: tsv row " + parseInt(rowIndex) + " has fewer columns than the tsv header!");
             }
 
             let rowArray = [];
             for ( const [colIndex, value] of row.entries() ) {
+
                 // Rows that are longer than the header should be truncated
                 if ( colIndex >= columnNames.length ) {
+
                     console.warn("WARNING: tsv row " + parseInt(rowIndex) + " has more columns than the tsv header!");
                     continue;
                 }
 
                 rowArray.push([columnNames[colIndex], value]);
             }
+
             dataTable.push(Object.fromEntries(rowArray));
         }
 

--- a/store/index.js
+++ b/store/index.js
@@ -244,7 +244,8 @@ export const getters = {
     getMappedCategories: (p_state) => (p_skipCategories=[]) => {
 
         // Return list of all categories linked to columns (filtered by given categories to skip)
-        return [...new Set(Object.values(p_state.columnToCategoryMapping).filter(x => !p_skipCategories.has(x)))];
+        return [...new Set(Object.values(p_state.columnToCategoryMapping)
+                    .filter(category => !p_skipCategories.includes(category)))];
     },
 
     getMappedColumns: (p_state) => (p_category) => {

--- a/store/index.js
+++ b/store/index.js
@@ -241,11 +241,17 @@ export const getters = {
             p_state.dataDictionary.annotated[p_columnName].transformationHeuristic : "";
     },
 
-    getMappedCategories: (p_state) => (p_skipCategories=[]) => {
+    getMappedCategories: (p_state) => (p_categorySkipList) => {
 
-        // Return list of all categories linked to columns (filtered by given categories to skip)
-        return [...new Set(Object.values(p_state.columnToCategoryMapping)
-                    .filter(category => !p_skipCategories.includes(category)))];
+        // 1. Remove unmapped (null) columns and skipped categories
+        const currentCategories = Object.values(p_state.columnToCategoryMapping)
+            .filter(category => null !== category && !p_categorySkipList.includes(category));
+
+        // 2. Create a set of the unique mapped categories
+        const categorySet = new Set(currentCategories);
+
+        // Return the categories in array form
+        return [...categorySet];
     },
 
     getMappedColumns: (p_state) => (p_category) => {


### PR DESCRIPTION
In an effort to keep PRs small, this PR closes the first step of restoring the annotation page (access + tabs) now that the second phase of our store refactor is (mostly) complete. As such this PR is not yet testable via our e2e page tests since the annotation page itself is functionally incomplete and its related e2e tests need to also be refactored to adapt to changes we have made. (Closes #348.)

In addition to basic access to the page with its primary components loading, this PR also addresses the following, as noted in #347 : 

- Tabs now must look at new store configuration for info on their construction (previously in store field annotationDetails)

Here is a file by file explanation of the changes made thus far:

`annot-categorical.vue`
- `v-select` value attribute is temporarily disabled as this reflects a getter we missed in our refactor discussions: `getSelectedOption`. @surchs also noticed this and there will be a brief discussion about this in #374 
- Refactors for new parameterization of `changeMissingStatus` and `selectCategoricalOption` getters

`annot-categorical.cy.js`
- Tests updated for refactor and brought in line with how `annot-continuous-values` is tested (re: act/assert calls)

`annot-continuous-values.vue`
- Call to `setHeuristic` mutation brought in line with how `annot-categorical` handles `v-select` input by calling the relevant mutation directly. Removed wrapper function `commitHeuristic`

`annot-continuous-values.cy.js`
- Updated `changeMissingStatus` mock to take object argument its real store version takes

`annot-tab.vue`
- Simple removal of now unused `id-field`

`annotation.vue`
- Annotation tab creation no longer uses removed `annotationDetails` store field but rather `columnToCategoryMapping` (and `colorInfo` for coloring)
- The `annot-tab` child component's props have been greatly reduced here. Keeping commented out version for now for any remaining functionality needed in the next integration PR; specifically for missing values.
- A `categorySkipList` field has been added to the page for generality. Really, our current hardcoded behavior is that no tab should be created for `Subject ID` and this is passed to the new `getMappedCategories` getter
- Keeping commented out store maps and functionality until next integration PR
- See `index.js` below for new criteria created for access to the annotation page

`index.js`
- New getter `getMappedCategories` that looks at `columnToCategoryMapping` and returns a unique list of categories that have thus far been linked to columns in the input data table. A optional list of categories to skip returning is given as a parameter. The existence of this getter is up for discussion, but its creation seemed to make sense as opposed to placing this store functionality inside `annotation.vue`
- Because we have not yet had a discussion on how we want optional data dictionary key value pairs to be created, it is currently necessary to check for the existence of the `missingValues` list in both the `getMappedColumns` getter and `changeMissingStatus` mutation.
- New `isPageAccessible` criterion has been added for moving to the annotation page: `notOnlySubjectIDCategorized`. Discussion point here as well is whether or not we want to allow users to move to the annotation page without categorizing a column other than one as 'Subject ID'. This doesn't make sense if we have no other categorizations as with the current implementation no tabs would exist on the annotation page. In the previous implementation, all categories had hardcoded tabs via `annotationDetails`
- Change `selectCategoricalOption` mutation's parameters to one parameter object to bring it line with the rest of our store mutations
- Fix for missing values check in `getUniqueValues`

`store-getter-getMappedCategories.cy.js`
- New unit tests for new getter `getMappedCategories` for annotation page

`store-getter-isPageAccessible.cy.js`
- Changed test to account for new criteria where at least one column must be linked to a non-'Subject ID' category for the user to proceed to the annotation page

`store-mutation-selectCategoricalOption.cy.js`
- Updates for new object argument for `selectCategoricalOption` mutation
