### PR TITLE
Phase 2 refactor: Column linking/unlinking alters data dictionary

### DIFF
--- a/cypress/unit/store-mutation-alterColumnCategoryMapping.cy.js
+++ b/cypress/unit/store-mutation-alterColumnCategoryMapping.cy.js
@@ -1,41 +1,86 @@
 import { mutations } from "~/store";
 
+// Setup
+let store;
+
 describe("alterColumnCategoryMapping", () => {
+
+    beforeEach(() => {
+
+        store = {
+
+            state: {
+
+                columnToCategoryMapping : {
+
+                    "column1": "Age",
+                    "column2": null,
+                    "column3": "Sex",
+                    "column4": null,
+                    "column5": null
+                },
+
+                dataDictionary: {
+
+                    annotated: {
+
+                        column3: {
+
+                        }
+                    },
+
+                    userProvided: {
+
+                    }
+                }
+            }
+        };
+    });
 
     it("Removes the mapping of column to category if they're already mapped", () => {
 
-        const { alterColumnCategoryMapping } = mutations;
-        const state = {
-            columnToCategoryMapping : {
+        // Act
+        mutations.alterColumnCategoryMapping(store.state, { category: "Sex", column: "column3" });
 
-                "column1": "Age",
-                "column2": null,
-                "column3": "Sex",
-                "column4": null,
-                "column5": null
-          }
-      };
-
-      alterColumnCategoryMapping(state, { category: "Sex", column: "column3" });
-      expect(state.columnToCategoryMapping.column3).to.equal(null);
+        // Assert
+        expect(store.state.columnToCategoryMapping.column3).to.equal(null);
     });
 
     it("Changes the mapping of column to category if they're not already mapped", () => {
 
-        const { alterColumnCategoryMapping } = mutations;
-        const state = {
-            columnToCategoryMapping : {
-                "column1": "Age",
-                "column2": null,
-                "column3": "Sex",
-                "column4": null,
-                "column5": null
-            }
-        };
+        // Act
+        mutations.alterColumnCategoryMapping(store.state, { category: "someCategory", column: "column1" });
 
-        alterColumnCategoryMapping(state, { category: "someCategory", column: "column1" });
-        expect(state.columnToCategoryMapping.column1).to.equal("someCategory");
-        alterColumnCategoryMapping(state, { category: "someCategory", column: "column2" });
-        expect(state.columnToCategoryMapping.column2).to.equal("someCategory");
+        // Assert
+        expect(store.state.columnToCategoryMapping.column1).to.equal("someCategory");
+        expect(store.state.dataDictionary.annotated.column1).to.deep.equal({ description: "" });
+
+        // Act
+        mutations.alterColumnCategoryMapping(store.state, { category: "someCategory", column: "column2" });
+
+        // Assert
+        expect(store.state.columnToCategoryMapping.column2).to.equal("someCategory");
+        expect(store.state.dataDictionary.annotated.column2).to.deep.equal({ description: "" });
+    });
+
+    it("Unlink a category from a column that is not listed in the user provided data dictionary", () => {
+
+        // Act
+        mutations.alterColumnCategoryMapping(store.state, { category: "Sex", column: "column3" });
+
+        // Assert
+        expect(store.state.dataDictionary.annotated["column3"]).to.deep.equal({ "description": "" });
+    });
+
+    it("Unlink a category from a column that is listed in the user provided data dictionary", () => {
+
+        // Setup
+        store.state.dataDictionary.userProvided["column3"] = { description: "filled in description" };
+
+        // Act
+        mutations.alterColumnCategoryMapping(store.state, { category: "Sex", column: "column3" });
+
+        // Assert
+        expect(store.state.dataDictionary.annotated["column3"]).to.deep.equal({ description: "filled in description" });
     });
 });

--- a/store/index.js
+++ b/store/index.js
@@ -473,13 +473,26 @@ export const mutations = {
      */
     alterColumnCategoryMapping(p_state, { category, column }) {
 
-        if (p_state.columnToCategoryMapping[column] === category) {
+        if ( category === p_state.columnToCategoryMapping[column] ) {
 
+            // 1. Unlink the column from the category
             p_state.columnToCategoryMapping[column] = null;
+
+            // 2. Revert the annotated data dictionary column definition to the one given
+            p_state.dataDictionary.annotated[column] = Object.assign(
+                {},
+                p_state.dataDictionary.annotated[column],
+                ( column in p_state.dataDictionary.userProvided ) ?
+                    p_state.dataDictionary.userProvided[column] : { description: "" }
+            );
         }
         else {
 
+            // 1. Link the column to the category
             p_state.columnToCategoryMapping[column] = category;
+
+            // 2. Add an entry for this column in the annotated data dictionary
+            p_state.dataDictionary.annotated[column] = { description: "" };
         }
     },
 


### PR DESCRIPTION
This PR implements #376.

- [ ] Unlinking a column from a category either reverts to the version of the column entry in `dataDictionary.userProvided.<column-name>` or if one hasn't been provided the default `{ description: "" }`
- [ ] Linking a column to a category initializes `dataDictionary.annotated.<column-name>` to `{ description: "" }`

Unit tests for `alterColumnCategoryMapping` now use a `beforeEach` to load up a `store` object and new tests for the above implementation have been added.