### PR TITLE
Replace remaining getSelectedOption instances and fix optional chaining bug with new getter

### DIFF
--- a/components/annot-categorical.vue
+++ b/components/annot-categorical.vue
@@ -98,7 +98,7 @@
             ...mapGetters([
 
                 "getCategoricalOptions",
-                "getSelectedOption",
+                "getSelectedCategoricalOption",
                 "getUniqueValues",
                 "getValueDescription"
             ]),

--- a/cypress/component/annot-categorical.cy.js
+++ b/cypress/component/annot-categorical.cy.js
@@ -167,8 +167,9 @@ describe("Categorical annotation", () => {
 
         // Setup
         cy.mount(annotCategorical, {
+
             computed: Object.assign(store.getters, { getCategoricalOptions: () => (p_column) => [],
-                getSelectedOption: () => (p_rowIndex) => null }),
+                getSelectedCategoricalOption: () => (p_rowIndex) => null }),
             mocks: { $store: store },
             propsData: props
         });

--- a/store/index.js
+++ b/store/index.js
@@ -146,7 +146,7 @@ export const getters = {
 
     getSelectedCategoricalOption: (p_state) => (p_column, p_rawValue) => {
 
-        return p_state.dataDictionary.annotated[p_column]?.valueMap[p_rawValue] ?? "";
+        return p_state.dataDictionary.annotated?.[p_column]?.valueMap?.[p_rawValue] ?? "";
     },
 
     getCategoryNames (p_state) {


### PR DESCRIPTION
There were two remaining instances of `getSelectedOption` after PR #377 that were breaking the app when manually running through to the annotation page. (They would have been noticed with the integration test for the annotation page enabled.)

In addition, after that a bug was discovered in the improper use of the optional chaining `?.` syntax in the new `getSelectedCategorical` getter. The operator before array `[]` syntax is still `?.`