### PR TITLE
Implemented `updateAnnotationCount` mutation

### DIFF
--- a/components/annot-categorical.vue
+++ b/components/annot-categorical.vue
@@ -29,7 +29,7 @@
                             :value="getSelectedCategoricalOption(row.item['columnName'], row.item['rawValue'])"
                             :label="label"
                             :reduce="term => term.identifier"
-                            @input="selectCategoricalOption({optionValue: $event, columnName: row.item['columnName'], rawValue: row.item['rawValue']})"
+                            @input="selectCategoricalOption({optionValue: $event, columnName: row.item['columnName'], rawValue: row.item['rawValue']}); updateAnnotationCount();"
                             :options="getCategoricalOptions(row.item['columnName'])" />
                     </template>
                     <template #cell(missingValue)="row">
@@ -132,7 +132,8 @@
             ...mapMutations([
 
                 "changeMissingStatus",
-                "selectCategoricalOption"
+                "selectCategoricalOption",
+                "updateAnnotationCount"
             ])
         }
     };

--- a/components/annot-continuous-values.vue
+++ b/components/annot-continuous-values.vue
@@ -41,7 +41,7 @@
                                 :data-cy="'selectTransform_' + columnName"
                                 :options="getTransformOptions(activeCategory)"
                                 :value="getHeuristic(columnName)"
-                                @input="setHeuristic({ column: columnName, heuristic: $event })" />
+                                @input="setHeuristic({ column: columnName, heuristic: $event }); updateAnnotationCount();" />
                         </b-col>
 
                     </b-row>
@@ -104,7 +104,8 @@
             ...mapMutations([
 
                 "changeMissingStatus",
-                "setHeuristic"
+                "setHeuristic",
+                "updateAnnotationCount"
             ]),
 
             columnValidationItems(p_columnName) {

--- a/cypress/component/annot-categorical.cy.js
+++ b/cypress/component/annot-categorical.cy.js
@@ -53,7 +53,8 @@ describe("Categorical annotation", () => {
             mutations: {
 
                 changeMissingStatus: () => ({ column, value, markAsMissing }) => {},
-                selectCategoricalOption: () => ({ optionValue, columnName, rawValue }) => {}
+                selectCategoricalOption: () => ({ optionValue, columnName, rawValue }) => {},
+                updateAnnotationCount: () => () => { return 0; }
             }
         };
     });

--- a/cypress/component/annot-continuous-values.cy.js
+++ b/cypress/component/annot-continuous-values.cy.js
@@ -62,7 +62,8 @@ describe("Continuous values component", () => {
                 setHeuristic: ({ column, heuristic }) => {
 
                     store.state.dataDictionary.annotated[column].transformationHeuristic = heuristic;
-                }
+                },
+                updateAnnotationCount: () => () => { return 0; }
             },
 
             state: {

--- a/cypress/unit/store-mutation-updateAnnotationCount.cy.js
+++ b/cypress/unit/store-mutation-updateAnnotationCount.cy.js
@@ -1,0 +1,107 @@
+import { mutations } from "~/store";
+
+let store;
+
+describe("updateAnnotationCount", () => {
+
+    beforeEach(() => {
+
+        store = {
+            state: {
+                annotationCount: 0,
+
+                dataDictionary: {
+                    annotated: {
+                        column1: {},
+                        column2: {},
+                        column3: {
+                            valueMap: {}
+                        },
+                        column4: {}
+                    }
+                }
+            }
+        };
+    });
+
+    it("Annotate and remove the annotation of a continuous value column", () => {
+
+        mutations.setHeuristic(store.state, {
+            column: "column1",
+            heuristic: "column1Heuristic"
+        });
+
+        mutations.updateAnnotationCount(store.state);
+
+        expect(store.state.annotationCount).to.equal(1);
+
+        mutations.setHeuristic(store.state, {
+            column: "column1",
+            heuristic: null
+        });
+
+        mutations.updateAnnotationCount(store.state);
+
+        expect(store.state.annotationCount).to.equal(0);
+
+    });
+
+    it("Annotate and remove the annotation of a categorical value column", () => {
+
+        mutations.selectCategoricalOption(store.state, {
+            optionValue: "https://example.org/female",
+            columnName: "column2",
+            rawValue: "F"
+        });
+
+        mutations.updateAnnotationCount(store.state);
+
+        expect(store.state.annotationCount).to.equal(1);
+
+        mutations.selectCategoricalOption(store.state, {
+            optionValue: null,
+            columnName: "column2",
+            rawValue: "F"
+        });
+
+        mutations.updateAnnotationCount(store.state);
+
+        expect(store.state.annotationCount).to.equal(0);
+
+    });
+
+    it("Annotate multiple columns", () => {
+
+        mutations.selectCategoricalOption(store.state, {
+            optionValue: "https://example.org/female",
+            columnName: "column2",
+            rawValue: "F"
+        });
+
+        mutations.selectCategoricalOption(store.state, {
+            optionValue: "https://example.org/male",
+            columnName: "column2",
+            rawValue: "M"
+        });
+
+        mutations.updateAnnotationCount(store.state);
+
+        mutations.setHeuristic(store.state, {
+            column: "column1",
+            heuristic: "column1Heuristic"
+        });
+
+        mutations.updateAnnotationCount(store.state);
+
+        mutations.setHeuristic(store.state, {
+            column: "column4",
+            heuristic: "column4Heuristic"
+        });
+
+        mutations.updateAnnotationCount(store.state);
+
+        expect(store.state.annotationCount).to.equal(3);
+
+    });
+
+});

--- a/store/index.js
+++ b/store/index.js
@@ -3,6 +3,7 @@ import { Set } from "core-js";
 import Vue from "vue";
 
 export const state = () => ({
+    annotationCount: 0,
 
     appSetting: {
 
@@ -604,5 +605,22 @@ export const mutations = {
 
         // Set a new transformation heuristic for this column
         Vue.set(p_state.dataDictionary.annotated[column], "transformationHeuristic", heuristic);
+    },
+
+    updateAnnotationCount(p_state) {
+        let count = 0;
+
+        Object.keys(p_state.dataDictionary.annotated).forEach(columnName => {
+            const column = p_state.dataDictionary.annotated[columnName];
+
+            if (column.valueMap && column.valueMap != {}) {
+                count++;
+            }
+            if (column.transformationHeuristic && column.transformationHeuristic != null) {
+                count++;
+            }
+        });
+
+        p_state.annotationCount = count;
     }
 };

--- a/store/index.js
+++ b/store/index.js
@@ -533,8 +533,14 @@ export const mutations = {
             p_state.dataDictionary.annotated[columnName].valueMap = {};
         }
 
-        // 1. Assign the option value to a raw value for this column
-        p_state.dataDictionary.annotated[columnName].valueMap[rawValue] = optionValue;
+        if (optionValue === null) {
+
+            delete p_state.dataDictionary.annotated[columnName].valueMap[rawValue];
+        }
+        else {
+            // 1. Assign the option value to a raw value for this column
+            p_state.dataDictionary.annotated[columnName].valueMap[rawValue] = optionValue;
+        }
     },
 
     setCurrentPage(p_state, p_pageName) {
@@ -613,10 +619,10 @@ export const mutations = {
         Object.keys(p_state.dataDictionary.annotated).forEach(columnName => {
             const column = p_state.dataDictionary.annotated[columnName];
 
-            if (column.valueMap && column.valueMap != {}) {
+            if (column.valueMap && Object.keys(column.valueMap).length > 0) {
                 count++;
             }
-            if (column.transformationHeuristic && column.transformationHeuristic != null) {
+            if (column.transformationHeuristic && column.transformationHeuristic !== null) {
                 count++;
             }
         });

--- a/store/index.js
+++ b/store/index.js
@@ -533,6 +533,8 @@ export const mutations = {
             p_state.dataDictionary.annotated[columnName].valueMap = {};
         }
 
+        // If the empty (null) option from v-select dropdown is selected remove
+        // the rawValue from the valueMap
         if (optionValue === null) {
 
             delete p_state.dataDictionary.annotated[columnName].valueMap[rawValue];
@@ -621,8 +623,7 @@ export const mutations = {
 
             if (column.valueMap && Object.keys(column.valueMap).length > 0) {
                 count++;
-            }
-            if (column.transformationHeuristic && column.transformationHeuristic !== null) {
+            } else if (column.transformationHeuristic && column.transformationHeuristic !== null) {
                 count++;
             }
         });


### PR DESCRIPTION
This PR includes:

- Implementation of `updateAnnotationCount` mutation
   - A categorical column is considered annotated if:
      - It contains `valueMap`
      - Its `valueMap` is not empty
   - A continuous column is considered annotated if:
      - It contains `transformationHeuristic`
      - Its `transformationHeuristic` is not `null`
- `updateAnnotationCount` unit-test
- Modification made to `selectCategoricalOption` mutation, if the empty option from the v-select is selected `rawValue` is removed from the `valueMap`

Closes #388
