### PR TITLE
Capitalized references of `description` in store and updated affected unit tests

### DIFF
--- a/cypress/unit/store-getter-getColumnDescription.cy.js
+++ b/cypress/unit/store-getter-getColumnDescription.cy.js
@@ -5,7 +5,7 @@ const state = {
     dataDictionary : {
         annotated: {
             "describedColumn": {
-                description: "This is my first column"
+                Description: "This is my first column"
             },
             "lazyColumn": {}
         }

--- a/cypress/unit/store-mutation-initializeDataDictionary.cy.js
+++ b/cypress/unit/store-mutation-initializeDataDictionary.cy.js
@@ -30,19 +30,19 @@ describe("initializeDataDictionary", () => {
         // Assert
         expect(state.dataDictionary.userProvided).to.deep.equal({
             "col1": {
-                description: ""
+                Description: ""
             },
             "col2": {
-                description: ""
+                Description: ""
             }
         });
         expect(state.dataDictionary.annotated).to.deep.equal({
             "col1": {
-                description: "",
+                Description: "",
                 missingValues: []
             },
             "col2": {
-                description: "",
+                Description: "",
                 missingValues: []
             }
         });
@@ -62,19 +62,19 @@ describe("initializeDataDictionary", () => {
         // Assert
         expect(state.dataDictionary.userProvided).to.deep.equal({
             "col1": {
-                description: ""
+                Description: ""
             },
             "col2": {
-                description: ""
+                Description: ""
             }
         });
         expect(state.dataDictionary.annotated).to.deep.equal({
             "col1": {
-                description: "",
+                Description: "",
                 missingValues: []
             },
             "col2": {
-                description: "",
+                Description: "",
                 missingValues: []
             }
         });

--- a/store/index.js
+++ b/store/index.js
@@ -154,9 +154,9 @@ export const getters = {
     getColumnDescription: (p_state) => (p_columnName) => {
 
 
-        if ( Object.hasOwn(p_state.dataDictionary.annotated[p_columnName], "description") ) {
+        if ( Object.hasOwn(p_state.dataDictionary.annotated[p_columnName], "Description") ) {
 
-            return p_state.dataDictionary.annotated[p_columnName].description;
+            return p_state.dataDictionary.annotated[p_columnName].Description;
         }
         else {
 
@@ -512,7 +512,7 @@ export const mutations = {
         // 1. Create a skeleton data dictionary based on the data table's columns
         for ( const columnName of Object.keys(p_state.dataTable[0]) ) {
 
-            p_state.dataDictionary.userProvided[columnName] = { "description": "" };
+            p_state.dataDictionary.userProvided[columnName] = { "Description": "" };
         }
 
         // 2. Make a copy of the newly provided skeleton dictionary for annotation


### PR DESCRIPTION
This PR includes the fix for the bug outlined in #384.
Changes include changing `description` references to `Description` in
- index.js
- store-mutation-initializeDataDictionary.cy.js
- store-getter-getColumDescription.cy.js


Closes #384 