### PR TITLE
Categorical Select bugfix + Rework of initialization of data dictionary columns for data types

### DIFF
--- a/components/annot-categorical.vue
+++ b/components/annot-categorical.vue
@@ -24,20 +24,12 @@
                             term.identifier parameter, but still display the term.label parameter to the user.
                             See: https://vue-select.org/guide/values.html#transforming-selections -->
 
-                        <!-- <v-select
-                            :data-cy="'categoricalSelector' + '_' + row.index"
-                            :value="getSelectedCategoricalOption(row.item['columnName'], row.item['rawValue'])"
-                            :reduce="term => term.identifier"
-                            @input="selectCategoricalOption({optionValue: $event, columnName: row.item['columnName'], rawValue: row.item['rawValue']}); updateAnnotationCount();"
-                            :options="getCategoricalOptions(row.item['columnName'])" /> -->
-
-                        <!-- :value="getSelectedCategoricalOption(row.item['columnName'], row.item['rawValue'])" -->
-
                         <v-select
                             :data-cy="'categoricalSelector' + '_' + row.index"
                             :options="getCategoricalOptions(row.item['columnName'])"
-                            :value="selectedValues[row.item['columnName']][row.item['rawValue']]"
-                            @input="selectCategoricalOption({ optionValue: $event, columnName: row.item['columnName'], rawValue: row.item['rawValue'] })" />
+                            :reduce="term => term.identifier"
+                            :value="getSelectedCategoricalOption(row.item['columnName'], row.item['rawValue'])"
+                            @input="selectOptionAndUpdate($event, row.item['columnName'], row.item['rawValue'])" />
 
                     </template>
                     <template #cell(missingValue)="row">
@@ -88,8 +80,6 @@
                     "missingValue"
                 ],
 
-                selectedValues: {},
-
                 // Text for UI elements
                 uiText: {
 
@@ -101,17 +91,11 @@
 
         },
 
-        mounted() {
-
-            this.getSelectedValues();
-        },
-
         computed: {
 
             ...mapGetters([
 
                 "getCategoricalOptions",
-                "getMappedColumns",
                 "getSelectedCategoricalOption",
                 "getUniqueValues",
                 "getValueDescription"
@@ -137,28 +121,8 @@
                     }
                 }
 
-                console.log(`Categorical table data: ${JSON.stringify(tableData)}`);
-
                 return tableData;
             }
-
-            // getSelectedValues() {
-
-            //     // 0. Retrieve data that will be used by the categorical dropdowns
-            //     const tableData = this.displayData();
-
-            //     // 1. Build a map of selected values by column for display in the v-selects
-            //     this.selectedValues = {};
-            //     for ( const row of tableData ) {
-
-            //         if ( !(row.columnName in this.selectedValues) ) {
-
-            //             this.selectedValues[row.columnName] = {};
-            //         }
-
-            //         this.selectedValues[row.columnName][row.rawValue] = this.getSelectedCategoricalOption(row.columnName, row.rawValue);
-            //     }
-            // }
         },
 
         methods: {
@@ -170,28 +134,18 @@
                 "updateAnnotationCount"
             ]),
 
-            getSelectedValues() {
+            selectOptionAndUpdate(p_optionValue, p_columnName, p_rawValue) {
 
-                // 1. Populate selectedValues with the columns linked to this category
-                this.selectedValues = Object.fromEntries(() => {
+                // 1. Set the categoricla option for this value in the store
+                this.selectCategoricalOption({
 
-                    return this.getMappedColumns(this.activeCategory).map(columnName => {
-
-                        return [columnName, ""];
-                    });
+                    optionValue: p_optionValue,
+                    columnName: p_columnName,
+                    rawValue: p_rawValue
                 });
 
-                // 2. Populate the columns of selectedValues with data dictionary's annotated values
-                Object.keys(this.displayTable).forEach(row => {
-
-                    this.selectedValues[row.columnName][row.rawValue] = this.getSelectedCategoricalOption(row.columnName, row.rawValue);
-                });
-            },
-
-            selectCategoricalOptionWrapper({ optionValue, columnName, rawValue }) {
-
-                this.getSelectedValues();
-                this.selectCategoricalOptin({ optionValue, columnName, rawValue });
+                // 2. Update the annotation count
+                this.updateAnnotationCount();
             }
         }
     };

--- a/components/annot-categorical.vue
+++ b/components/annot-categorical.vue
@@ -24,13 +24,21 @@
                             term.identifier parameter, but still display the term.label parameter to the user.
                             See: https://vue-select.org/guide/values.html#transforming-selections -->
 
-                        <v-select
+                        <!-- <v-select
                             :data-cy="'categoricalSelector' + '_' + row.index"
                             :value="getSelectedCategoricalOption(row.item['columnName'], row.item['rawValue'])"
-                            :label="label"
                             :reduce="term => term.identifier"
                             @input="selectCategoricalOption({optionValue: $event, columnName: row.item['columnName'], rawValue: row.item['rawValue']}); updateAnnotationCount();"
-                            :options="getCategoricalOptions(row.item['columnName'])" />
+                            :options="getCategoricalOptions(row.item['columnName'])" /> -->
+
+                        <!-- :value="getSelectedCategoricalOption(row.item['columnName'], row.item['rawValue'])" -->
+
+                        <v-select
+                            :data-cy="'categoricalSelector' + '_' + row.index"
+                            :options="getCategoricalOptions(row.item['columnName'])"
+                            :value="selectedValues[row.item['columnName']][row.item['rawValue']]"
+                            @input="selectCategoricalOption({ optionValue: $event, columnName: row.item['columnName'], rawValue: row.item['rawValue'] })" />
+
                     </template>
                     <template #cell(missingValue)="row">
                         <b-button
@@ -80,17 +88,22 @@
                     "missingValue"
                 ],
 
+                selectedValues: {},
+
                 // Text for UI elements
                 uiText: {
 
                     instructions: "Annotate each unique value",
                     missingValueButton: "Mark as missing",
                     saveButton: "Save Annotation"
-                },
-
-                valueMapping: {}
+                }
             };
 
+        },
+
+        mounted() {
+
+            this.getSelectedValues();
         },
 
         computed: {
@@ -98,6 +111,7 @@
             ...mapGetters([
 
                 "getCategoricalOptions",
+                "getMappedColumns",
                 "getSelectedCategoricalOption",
                 "getUniqueValues",
                 "getValueDescription"
@@ -112,7 +126,7 @@
                 const tableData = [];
 
                 for ( const columnName in uniqueValuesMap ) {
-                    for ( const uniqueValue of uniqueValuesMap[columnName]) {
+                    for ( const uniqueValue of uniqueValuesMap[columnName] ) {
 
                         tableData.push({
 
@@ -123,8 +137,28 @@
                     }
                 }
 
+                console.log(`Categorical table data: ${JSON.stringify(tableData)}`);
+
                 return tableData;
             }
+
+            // getSelectedValues() {
+
+            //     // 0. Retrieve data that will be used by the categorical dropdowns
+            //     const tableData = this.displayData();
+
+            //     // 1. Build a map of selected values by column for display in the v-selects
+            //     this.selectedValues = {};
+            //     for ( const row of tableData ) {
+
+            //         if ( !(row.columnName in this.selectedValues) ) {
+
+            //             this.selectedValues[row.columnName] = {};
+            //         }
+
+            //         this.selectedValues[row.columnName][row.rawValue] = this.getSelectedCategoricalOption(row.columnName, row.rawValue);
+            //     }
+            // }
         },
 
         methods: {
@@ -134,7 +168,31 @@
                 "changeMissingStatus",
                 "selectCategoricalOption",
                 "updateAnnotationCount"
-            ])
+            ]),
+
+            getSelectedValues() {
+
+                // 1. Populate selectedValues with the columns linked to this category
+                this.selectedValues = Object.fromEntries(() => {
+
+                    return this.getMappedColumns(this.activeCategory).map(columnName => {
+
+                        return [columnName, ""];
+                    });
+                });
+
+                // 2. Populate the columns of selectedValues with data dictionary's annotated values
+                Object.keys(this.displayTable).forEach(row => {
+
+                    this.selectedValues[row.columnName][row.rawValue] = this.getSelectedCategoricalOption(row.columnName, row.rawValue);
+                });
+            },
+
+            selectCategoricalOptionWrapper({ optionValue, columnName, rawValue }) {
+
+                this.getSelectedValues();
+                this.selectCategoricalOptin({ optionValue, columnName, rawValue });
+            }
         }
     };
 

--- a/components/annot-columns.vue
+++ b/components/annot-columns.vue
@@ -18,7 +18,7 @@
                     <b-button
                         :data-cy="'remove_' + columnName"
                         variant="danger"
-                        @click="alterColumnCategoryMapping({category: activeCategory, column: columnName})">
+                        @click="alterColumnCategoryMapping({category: activeCategory, columnName: columnName})">
                         {{ uiText.removeButton }}
                     </b-button>
                 </b-list-group-item>

--- a/components/annot-continuous-values.vue
+++ b/components/annot-continuous-values.vue
@@ -41,7 +41,7 @@
                                 :data-cy="'selectTransform_' + columnName"
                                 :options="getTransformOptions(activeCategory)"
                                 :value="getHeuristic(columnName)"
-                                @input="setHeuristic({ column: columnName, heuristic: $event }); updateAnnotationCount();" />
+                                @input="selectHeuristic({ columnName: columnName, heuristic: $event})" />
                         </b-col>
 
                     </b-row>
@@ -114,17 +114,26 @@
                 const uniqueValuesByColumn = this.getUniqueValues(this.activeCategory);
 
                 // 2. Create items for the table consisting of objects containing column name, raw and transformed values
-                const tableItems = [];
+                const tableItemsForColumn = [];
                 uniqueValuesByColumn[p_columnName].forEach(value => {
 
-                    tableItems.push({
+                    tableItemsForColumn.push({
 
                         preview: this.getHarmonizedPreview(p_columnName, value),
                         rawValue: value
                     });
                 });
 
-                return tableItems;
+                return tableItemsForColumn;
+            },
+
+            selectHeuristic({ columnName, heuristic }) {
+
+                // 1. Set the heuristic for this column in the store
+                this.setHeuristic({ columnName: columnName, heuristic: heuristic });
+
+                // 2. Update the annotation count
+                this.updateAnnotationCount();
             }
         }
     };

--- a/components/column-linking-table.vue
+++ b/components/column-linking-table.vue
@@ -4,14 +4,14 @@
 
         <!-- Category to column linking table -->
         <b-table
-            data-cy="column-linking-table-table"
             bordered
             outlined
-            :fields="uiText.tableFields"
+            data-cy="column-linking-table-table"
             head-variant="dark"
+            :fields="uiText.tableFields"
             :items="tableRows"
-            @row-clicked="applyCategory"
-            :tbody-tr-class="styleTableRow" />
+            :tbody-tr-class="styleTableRow"
+            @row-clicked="applyCategory" />
 
     </b-container>
 
@@ -79,7 +79,7 @@
             applyCategory(p_row, p_index, p_event) {
 
                 // Link or unlink the currently-selected/active category and the clicked column
-                this.alterColumnCategoryMapping({ category: this.selectedCategory, column: p_row.column });
+                this.alterColumnCategoryMapping({ category: this.selectedCategory, columnName: p_row.column });
             },
 
             styleTableRow(p_row, p_rowType) {

--- a/cypress/component/annot-columns.cy.js
+++ b/cypress/component/annot-columns.cy.js
@@ -16,7 +16,7 @@ const store = {
         }
     },
     mutations: {
-        alterColumnCategoryMapping: () => ({category, column}) => {}
+        alterColumnCategoryMapping: () => ({ category, columnName }) => {}
     }
 };
 
@@ -49,7 +49,7 @@ describe("columns annotation", () =>  {
             }
         });
         cy.get("[data-cy='remove_column2']").click();
-        cy.get("@commitSpy").should("have.been.calledOnceWith", "alterColumnCategoryMapping", {category: "someCategory", column: "column2"});
+        cy.get("@commitSpy").should("have.been.calledOnceWith", "alterColumnCategoryMapping", {category: "someCategory", columnName: "column2"});
     });
 });
 

--- a/cypress/component/annot-continuous-values.cy.js
+++ b/cypress/component/annot-continuous-values.cy.js
@@ -59,9 +59,9 @@ describe("Continuous values component", () => {
                 // NOTE: changeMissingStatus reflects a future 'mark as missing' feature
                 // for the continous value component
                 changeMissingStatus: () => ({ column, value, markAsMissing}) => {},
-                setHeuristic: ({ column, heuristic }) => {
+                setHeuristic: ({ columnName, heuristic }) => {
 
-                    store.state.dataDictionary.annotated[column].transformationHeuristic = heuristic;
+                    store.state.dataDictionary.annotated[columnName].transformationHeuristic = heuristic;
                 },
                 updateAnnotationCount: () => () => { return 0; }
             },
@@ -122,7 +122,7 @@ describe("Continuous values component", () => {
             .click();
 
         // Assert
-        cy.get("@commitSpy").should("have.been.calledWith", "setHeuristic", { column: "column1", heuristic: "float" });
+        cy.get("@commitSpy").should("have.been.calledWith", "setHeuristic", { columnName: "column1", heuristic: "float" });
     });
 
     it("Applies a selected heuristic and previews transformed values", () => {

--- a/cypress/component/column-linking-table.cy.js
+++ b/cypress/component/column-linking-table.cy.js
@@ -138,6 +138,6 @@ describe("The column-linking-table component", () => {
             .click();
 
         // 3. Assert - Make sure linking mutation is commited to the store
-        cy.get("@commitSpy").should("have.been.calledWith", "alterColumnCategoryMapping", { category: subjectIDCategory, column: participantIDColumn });
+        cy.get("@commitSpy").should("have.been.calledWith", "alterColumnCategoryMapping", { category: subjectIDCategory, columnName: participantIDColumn });
     });
 });

--- a/cypress/unit/store-getter-getHeuristic.cy.js
+++ b/cypress/unit/store-getter-getHeuristic.cy.js
@@ -15,7 +15,10 @@ describe("The getHeuristic getter", () => {
                     userProvided: {},
                     annotated: {
 
-                        column1: {}
+                        column1: {
+
+                            transformationHeuristic: ""
+                        }
                     }
                 }
             }

--- a/cypress/unit/store-getter-getSelectedCategoricalOption.cy.js
+++ b/cypress/unit/store-getter-getSelectedCategoricalOption.cy.js
@@ -10,6 +10,20 @@ describe("getSelectedCategoricalOption", () => {
 
             state: {
 
+                categoricalOptions: {
+
+                    category1: [{
+
+                        label: "option1Label",
+                        identifier: "optionIdentifier"
+                    }]
+                },
+
+                columnToCategoryMap: {
+
+                    column1: "category1"
+                },
+
                 dataDictionary: {
 
                     annotated: {
@@ -18,7 +32,7 @@ describe("getSelectedCategoricalOption", () => {
 
                             valueMap: {
 
-                                "raw_value1": "annotated_value1"
+                                "raw_value1": "optionIdentifier"
                             }
                         }
                     }
@@ -33,7 +47,7 @@ describe("getSelectedCategoricalOption", () => {
         const mappedValue = getters.getSelectedCategoricalOption(store.state)("column1", "raw_value1");
 
         // Assert
-        expect(mappedValue).to.equal("annotated_value1");
+        expect(mappedValue).to.equal("option1Label");
     });
 
     it("Attempt to get a value mapped to raw value that does not exist in a column that exists in the value map", () => {
@@ -42,15 +56,6 @@ describe("getSelectedCategoricalOption", () => {
         const mappedValue = getters.getSelectedCategoricalOption(store.state)("column1", "raw_value2");
 
         // Assert - If a raw value is not found in the column in the value map, a blank string should be returned
-        expect(mappedValue).to.equal("");
-    });
-
-    it("Attempt to get a value mapped to a raw value in a column that does not exist in the value map", () => {
-
-        // Act
-        const mappedValue = getters.getSelectedCategoricalOption(store.state)("column2", "raw_value1");
-
-        // Assert - If a column is not found in the value map, a blank string should be returned
         expect(mappedValue).to.equal("");
     });
 });

--- a/cypress/unit/store-mutation-alterColumnCategoryMap.cy.js
+++ b/cypress/unit/store-mutation-alterColumnCategoryMap.cy.js
@@ -82,4 +82,28 @@ describe("alterColumnCategoryMapping", () => {
         expect(store.state.columnToCategoryMap.column2).to.equal("someCategory");
         expect(store.state.dataDictionary.annotated.column2).to.deep.equal(reinitializedAnnotatedColumn);
     });
+
+    it("Makes sure a value map is created for a categorical column in the data dictionary", () => {
+
+        // Act
+        mutations.alterColumnCategoryMapping(store.state, {
+            category: "Sex",
+            columnName: "column2"
+        });
+
+        // Assert
+        expect(store.state.dataDictionary.annotated.column2.valueMap).to.exist;
+    });
+
+    it("Makes sure a transformation heuristic is created for a continuous values column in the data dictionary", () => {
+
+        // Act
+        mutations.alterColumnCategoryMapping(store.state, {
+            category: "Age",
+            columnName: "column2"
+        });
+
+        // Assert
+        expect(store.state.dataDictionary.annotated.column2.transformationHeuristic).to.exist;
+    });
 });

--- a/cypress/unit/store-mutation-alterColumnCategoryMap.cy.js
+++ b/cypress/unit/store-mutation-alterColumnCategoryMap.cy.js
@@ -60,7 +60,7 @@ describe("alterColumnCategoryMapping", () => {
     it("Removes the mapping of column to category if they're already mapped", () => {
 
         // Act
-        mutations.alterColumnCategoryMapping(store.state, { category: "Sex", column: "column3" });
+        mutations.alterColumnCategoryMapping(store.state, { category: "Sex", columnName: "column3" });
 
         // Assert
         expect(store.state.columnToCategoryMap.column3).to.equal(null);
@@ -69,14 +69,14 @@ describe("alterColumnCategoryMapping", () => {
     it("Changes the mapping of column to category if they're not already mapped", () => {
 
         // Act
-        mutations.alterColumnCategoryMapping(store.state, { category: "someCategory", column: "column1" });
+        mutations.alterColumnCategoryMapping(store.state, { category: "someCategory", columnName: "column1" });
 
         // Assert
         expect(store.state.columnToCategoryMap.column1).to.equal("someCategory");
         expect(store.state.dataDictionary.annotated.column1).to.deep.equal(reinitializedAnnotatedColumn);
 
         // Act
-        mutations.alterColumnCategoryMapping(store.state, { category: "someCategory", column: "column2" });
+        mutations.alterColumnCategoryMapping(store.state, { category: "someCategory", columnName: "column2" });
 
         // Assert
         expect(store.state.columnToCategoryMap.column2).to.equal("someCategory");

--- a/cypress/unit/store-mutation-selectCategoricalOption.cy.js
+++ b/cypress/unit/store-mutation-selectCategoricalOption.cy.js
@@ -10,11 +10,16 @@ describe("selectCategoricalOption mutation", () => {
 
             state: {
 
+                columnToCategoryMap: {},
+
                 dataDictionary: {
 
                     annotated: {
 
-                        column1: {}
+                        column1: {
+
+                            valueMap: {}
+                        }
                     }
                 }
             }
@@ -24,10 +29,9 @@ describe("selectCategoricalOption mutation", () => {
     it("Makes sure a value map is created for a column in the data dictionary", () => {
 
         // Act
-        mutations.selectCategoricalOption(store.state, {
-            optionValue: "https://example.org/female",
-            columnName: "column1",
-            rawValue: "F"
+        mutations.alterColumnCategoryMapping(store.state, {
+            category: "category1",
+            columnName: "column1"
         });
 
         // Assert

--- a/cypress/unit/store-mutation-selectCategoricalOption.cy.js
+++ b/cypress/unit/store-mutation-selectCategoricalOption.cy.js
@@ -26,18 +26,6 @@ describe("selectCategoricalOption mutation", () => {
         };
     });
 
-    it("Makes sure a value map is created for a column in the data dictionary", () => {
-
-        // Act
-        mutations.alterColumnCategoryMapping(store.state, {
-            category: "category1",
-            columnName: "column1"
-        });
-
-        // Assert
-        expect(store.state.dataDictionary.annotated.column1.valueMap).to.exist;
-    });
-
     it("Makes sure an annotated value is set in the value map", () => {
 
         // Act

--- a/cypress/unit/store-mutation-setHeuristic.cy.js
+++ b/cypress/unit/store-mutation-setHeuristic.cy.js
@@ -21,7 +21,7 @@ describe("setHeuristic", () => {
 
         // Act
         mutations.setHeuristic(state, {
-            column: "column1",
+            columnName: "column1",
             heuristic: "column1Heuristic"
         });
 
@@ -37,7 +37,7 @@ describe("setHeuristic", () => {
 
         // Act
         mutations.setHeuristic(state, {
-            column: "column1",
+            columnName: "column1",
             heuristic: "column1Heuristic"
         });
 

--- a/cypress/unit/store-mutation-updateAnnotationCount.cy.js
+++ b/cypress/unit/store-mutation-updateAnnotationCount.cy.js
@@ -8,16 +8,33 @@ describe("updateAnnotationCount", () => {
 
         store = {
             state: {
+
                 annotationCount: 0,
 
+                categories: {
+
+                    "Subject ID": {},
+                    "Age": { componentName: "annot-continuous-values" },
+                    "Sex": { componentName: "annot-categorical" },
+                    "Diagnosis": { componentName: "annot-categorical" }
+                },
+
+                columnToCategoryMap: {
+
+                    column1: "Age",
+                    column2: "Sex",
+                    column3: "Diagnosis",
+                    column4: "Age"
+                },
+
                 dataDictionary: {
+
                     annotated: {
-                        column1: {},
-                        column2: {},
-                        column3: {
-                            valueMap: {}
-                        },
-                        column4: {}
+
+                        column1: { transformationHeuristic: "" },
+                        column2: { valueMap: {} },
+                        column3: { valueMap: {} },
+                        column4: { transformationHeuristic: "" }
                     }
                 }
             }

--- a/cypress/unit/store-mutation-updateAnnotationCount.cy.js
+++ b/cypress/unit/store-mutation-updateAnnotationCount.cy.js
@@ -27,7 +27,7 @@ describe("updateAnnotationCount", () => {
     it("Annotate and remove the annotation of a continuous value column", () => {
 
         mutations.setHeuristic(store.state, {
-            column: "column1",
+            columnName: "column1",
             heuristic: "column1Heuristic"
         });
 
@@ -36,7 +36,7 @@ describe("updateAnnotationCount", () => {
         expect(store.state.annotationCount).to.equal(1);
 
         mutations.setHeuristic(store.state, {
-            column: "column1",
+            columnName: "column1",
             heuristic: null
         });
 
@@ -87,14 +87,14 @@ describe("updateAnnotationCount", () => {
         mutations.updateAnnotationCount(store.state);
 
         mutations.setHeuristic(store.state, {
-            column: "column1",
+            columnName: "column1",
             heuristic: "column1Heuristic"
         });
 
         mutations.updateAnnotationCount(store.state);
 
         mutations.setHeuristic(store.state, {
-            column: "column4",
+            columnName: "column4",
             heuristic: "column4Heuristic"
         });
 

--- a/store/index.js
+++ b/store/index.js
@@ -480,7 +480,7 @@ export const mutations = {
      * Otherwise the column is mapped to a different category
      *
      * @param {string} category Category the column should be mapped to
-     * @param {string} column Column that will be mapped to the category
+     * @param {string} columnName Column that will be mapped to the category
      */
     alterColumnCategoryMapping(p_state, { category, columnName }) {
 

--- a/store/index.js
+++ b/store/index.js
@@ -647,7 +647,7 @@ export const mutations = {
     setHeuristic(p_state, { columnName, heuristic }) {
 
         // Set a new transformation heuristic for this column
-        Vue.set(p_state.dataDictionary.annotated[columnName], "transformationHeuristic", heuristic);
+        Vue.set(p_state.dataDictionary.annotated[columnName], "transformationHeuristic", heuristic ?? "");
     },
 
     updateAnnotationCount(p_state) {
@@ -657,15 +657,25 @@ export const mutations = {
         // 1. Check each column in the data dictionary for annotations
         Object.keys(p_state.dataDictionary.annotated).forEach(columnName => {
 
+            // A. Get the annotated column object for this column
             const column = p_state.dataDictionary.annotated[columnName];
 
-            // A. Check for data type-specific structure and for what that data type counts as an annotation
-            if ( column.valueMap && Object.keys(column.valueMap).length > 0 ) {
+            // B. Get the mapped category for this column
+            const category = p_state.columnToCategoryMap[columnName];
 
-                count++;
-            } else if ( "" !== column.transformationHeuristic ) {
+            // Only categorized columns can have annotations
+            if ( null !== category ) {
 
-                count++;
+                // C. Check for data type and for what that data type counts as an annotation
+                if ( "annot-categorical" === p_state.categories[category].componentName &&
+                     Object.keys(column.valueMap).length > 0 ) {
+
+                    count++;
+                } else if ( "annot-continuous-values" === p_state.categories[category].componentName &&
+                            "" !== column.transformationHeuristic ) {
+
+                    count++;
+                }
             }
         });
 

--- a/store/index.js
+++ b/store/index.js
@@ -147,7 +147,6 @@ export const getters = {
 
     getCategoryNames (p_state) {
 
-
         return Object.keys(p_state.categories);
     },
 
@@ -317,9 +316,37 @@ export const getters = {
         return nextPage;
     },
 
-    getSelectedCategoricalOption: (p_state) => (p_column, p_rawValue) => {
+    getSelectedCategoricalOption: (p_state) => (p_columnName, p_rawValue) => {
 
-        return p_state.dataDictionary.annotated?.[p_column]?.valueMap?.[p_rawValue] ?? "";
+        console.log(`In getSelectedCategoricalOption`);
+
+        // If value map for the column doesn't exist OR
+        // If value map for the column does exist and the raw value does not exist in the value map, returns ""
+        let selectedCategoricalOption = "";
+
+        // If value map exists and raw value exists in value map,
+        // take annotated value and do reverse lookup of the label in p_state.categoricalOptions
+        if ( "valueMap" in p_state.dataDictionary.annotated[p_columnName] &&
+             p_rawValue in p_state.dataDictionary.annotated[p_columnName].valueMap ) {
+
+            const annotatedValue = p_state.dataDictionary.annotated[p_columnName].valueMap[p_rawValue];
+
+            // Reverse lookup here
+            for ( const optionObject of p_state.categoricalOptions[p_columnName] ) {
+
+                if ( annotatedValue === optionObject.identifier ) {
+
+                    console.log(`Found annotatedValue ${annotatedValue} and saving ${optionObject.label} as selected option`);
+
+                    selectedCategoricalOption = optionObject.label;
+                }
+            }
+        }
+
+        console.log(`In getSelectedCategoricalOption, returning: ${selectedCategoricalOption}`);
+
+        // return p_state.dataDictionary.annotated?.[p_column]?.valueMap?.[p_rawValue] ?? "";
+        return selectedCategoricalOption;
     },
 
     getTransformOptions: (p_state) => (p_category) => {


### PR DESCRIPTION
This PR addresses both #386 and #390. A list of changes made by file below.

**annot-categorical.vue**
- Removed `label` attribute for `v-select` as it was unnecessary and producing a warning. `value` is used for showing what was just selected and retrieving what had been selected upon component re-mount
- Added component function `selectOptionAndUpdate` as we would like to avoid multiline attribute code

**annot-continuous-values.vue**
- Added component function `selectHeuristic` as we would like to avoid multiline attribute code

**index.js**

_Formatting/streamlining_
- Added a comment to describe the new annotation count store field
- Small streamlining of `getColumnDescription`, `getHarmonizedPreview` implementation
- `updateAnnotationCount` - Updated this function for a clean check of data type for the column followed by the annotation condition. This way we do not have to worry about cascading conditions.

_Feature 390 - Initialization of specialized structures for data types_
- `alterColumnCategoryMapping` - this has been rewritten to allow for the addition of special structures `transformationHeuristic` and `valueMap` in `dataDictionary.annotated.<column-name>`. Determination of which should be added is dependent on the category assigned to each column in `dataDictionary.annotated.<column-name>`.
- `getHeuristic` - transformationHeuristic property will now always be present for continuous values-categorized columns

_Bug fix 386_
- `getSelectedCategoricalOption` - used to determine via lookup of stored `identifier` in `valueMap` what the label for that identifier is
- `selectCategoricalOption` - 1) Deletes values from the value map for categorical columns if the annotated value is removed (blank vue select),
and 2) Changes/adds the annotated value to the `valueMap` when an option is selected from the vue-select in `annot-categorical`
- `setHeuristic` - Either adds the heuristic from the drop down or deletes the heuristic for a column in `annot-continuous-values`

**Test updates for the fix and feature**
- `store-getter-getHeuristic.cy.js`
- `store-getter-getSelectedCategoricalOption.cy.js`
- `store-mutation-selectCategoricalOption.cy.js`
- `store-mutation-updateAnnotationCount.cy.js`

**Any string referring to data table column in the repo now is called `columnName`**
- `alterColumnCategoryMap.cy.js`
- `column-linking-table.cy.js`
- `annot-continuous-values.cy.js`
- `annot-columns.cy.js`
- `column-linking-table.vue` (In addition attributes for the `b-table` have been reordered.)
- `annot-columns.vue`



