### PR TITLE
Fixed the bug that made download page unreachable from annotation page

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,7 +9,7 @@
         <Nuxt />
 
         <!-- Next page button -->
-        <next-page />
+        <next-page v-if="getNextPage()!==''" />
 
     </div>
 
@@ -17,9 +17,19 @@
 
 <script>
 
+    import { mapGetters } from "vuex";
+
     export default {
 
-        name: "DefaultLayout"
+        name: "DefaultLayout",
+
+        methods: {
+
+            ...mapGetters([
+
+                "getNextPage"
+            ])
+        }
     };
 
 </script>

--- a/store/index.js
+++ b/store/index.js
@@ -312,6 +312,9 @@ export const getters = {
             case "annotation":
                 nextPage = "download";
                 break;
+            case "download":
+                nextPage = "";
+                break;
         }
 
         return nextPage;


### PR DESCRIPTION
This PR includes the fix for #394. 

Changes include:
- Implemented a case for the download page in the switch statement of `getNextPage` getter in `index.js`
- Implemented condition for displaying `next-page` component in `default.vue` layout component

Closes #394 