### PR TITLE
Removed `range` and `string` options from `transformationHeuristics`

### DIFF
--- a/cypress/component/annot-continuous-values.cy.js
+++ b/cypress/component/annot-continuous-values.cy.js
@@ -42,8 +42,8 @@ describe("Continuous values component", () => {
                 },
                 getTransformOptions: () => (p_activeCategory) => {
 
-                    // return ["float", "bounded", "euro", "range", "int", "string", "isoyear"];
-                    return ["", "float", "bounded", "euro", "range", "int", "string"];
+                    // return ["float", "bounded", "euro", "int", "isoyear"];
+                    return ["", "float", "bounded", "euro", "int"];
                 },
                 getUniqueValues: () => (p_activeCategory) => {
 

--- a/cypress/unit/store-getter-getHarmonizedPreview.cy.js
+++ b/cypress/unit/store-getter-getHarmonizedPreview.cy.js
@@ -111,34 +111,6 @@ describe("getHarmonizedPreview", () => {
         expect(harmonizedValue).to.equal(42.6);
     });
 
-    it("range transformation", () => {
-
-        // 1. Integer range transformation
-
-        // Setup
-        store.state.dataDictionary.annotated.column1.transformationHeuristic = "range";
-        originalValue = "42-44";
-
-        // Act
-        let harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
-
-        // Assert
-        expect(harmonizedValue).to.equal(43);
-
-        // 2. Floating point range transformation
-
-        // Setup
-        store.state.dataDictionary.annotated.column1.transformationHeuristic = "range";
-        originalValue = "42-43";
-
-        // Act
-        harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
-
-        // Assert
-        expect(harmonizedValue).to.equal(42.5);
-
-    });
-
     it("int transformation", () => {
 
         // Setup
@@ -150,18 +122,6 @@ describe("getHarmonizedPreview", () => {
 
         // Assert
         expect(harmonizedValue).to.equal(42);
-    });
-
-    it("string transformation", () => {
-
-        // Setup
-        store.state.dataDictionary.annotated.column1.transformationHeuristic = "string";
-
-        // Act
-        const harmonizedValue = getters.getHarmonizedPreview(store.state)("column1", originalValue);
-
-        // Assert
-        expect(harmonizedValue).to.equal(store.state.appSetting.missingValueLabel);
     });
 
     // it("isoyear transformation", () => {

--- a/cypress/unit/store-getter-getTransformOptions.cy.js
+++ b/cypress/unit/store-getter-getTransformOptions.cy.js
@@ -18,7 +18,7 @@ let store = {
 
             "annot-continuous-values": [
 
-                "float", "bounded", "euro", "range", "int", "string", "isoyear"
+                "float", "bounded", "euro", "int", "isoyear"
             ]
         }
     }
@@ -33,7 +33,7 @@ describe("getTransformOptions", () => {
 
         // Assert
         expect(options).to.deep.equal([
-            "float", "bounded", "euro", "range", "int", "string", "isoyear"
+            "float", "bounded", "euro", "int", "isoyear"
         ]);
     });
 });

--- a/store/index.js
+++ b/store/index.js
@@ -126,10 +126,10 @@ export const state = () => ({
     transformationHeuristics: {
 
         // "annot-continuous-values": [
-        //     "", "float", "bounded", "euro", "range", "int", "string", "isoyear"
+        //     "", "float", "bounded", "euro", "int", "isoyear"
         // ]
         "annot-continuous-values": [
-            "", "float", "bounded", "euro", "range", "int", "string"
+            "", "float", "bounded", "euro", "int"
         ]
     }
 });
@@ -196,21 +196,9 @@ export const getters = {
                 convertedValue = parseFloat(p_originalValue.replace(",", "."));
                 break;
 
-            case "range": {
-
-                const [lower, upper] = p_originalValue.split("-").map(val => parseFloat(val.trim()));
-                convertedValue = (lower + upper) / 2;
-                break;
-            }
-
             case "int":
 
                 convertedValue = parseInt(p_originalValue);
-                break;
-
-            case "string":
-
-                convertedValue = p_state.appSetting.missingValueLabel;
                 break;
 
             // case "isoyear": {


### PR DESCRIPTION
This PR includes the implementation of the fix for #392.

Changes include:

- Removal of the `range` and `string` options from `transformationHeuristics` in `index.js`
- Update of affected tests:
  - `annot-continuous-values.cy.js`
  - `getHarmonizedPreview.cy.js`
  - `getTransformOptions.cy.js`

Closes #392
