### PR TITLE
Removal of old download components and related functionality

### DIFF
--- a/pages/download.vue
+++ b/pages/download.vue
@@ -12,8 +12,7 @@
 
             <b-col cols="9" />
 
-            <!-- Button to proceed to download the annotation output data -->
-            <!-- Only enabled when annotation has been at least partially completed -->
+            <!-- Button to download the annotation output data -->
             <b-col cols="3">
                 <b-button
                     class="float-right"
@@ -32,7 +31,7 @@
 
 <script>
 
-    // Saves file to user's computer
+    // Saves annotated data dictionary to user's computer
     import { saveAs } from "file-saver";
 
     export default {
@@ -81,8 +80,8 @@
             // Leaving this code in as a reminder what the file saveAs functionality needs
             downloadAnnotatedData() {
 
-                // // 1. Format the annotated table into propietary JSON format
-                // const jsonData = this.transformAnnotatedTableToJSON();
+                // // 1. Format the annotated data dictionary into propietary JSON format
+                // const jsonData = this.transformAnnotatedDictionaryToJSON();
 
                 // // 2. Open file dialog to prompt the user to name it and
                 // // download it to their location of choice
@@ -91,18 +90,21 @@
 
             fileSaverSaveAs(p_jsonData) {
 
+                // 1. Create a blob version of the JSON output file
                 const blob = new Blob([JSON.stringify(p_jsonData, null, this.jsonSpacing)], {type: "text/plain;charset=utf-8"});
+
+                // 2. Open 'save as' file dialog box to allow user to save JSON output file to user's computer
                 saveAs(blob, this.defaultOutputFilename);
             }
 
             // transformAnnotatedTableToJSON() {
 
-            //     // Transform the annotated data table into a new subject-centric JSON format for the output file
+            //     // Transform the annotated data dictionary into a propietary JSON format for the output file
             //     return {
 
             //         name: this.datasetName,
             //         type: "dataset",
-            //         hasSamples: this.dataTable.annotated.map(row => this.transformAnnotatedRowToSubjectJSON(row))
+            //         hasSamples: Object.keys(this.dataDictionary.annotated).map(entry => this.transformDataDictionaryEntry(entry))
             //     };
             // }
         }

--- a/pages/download.vue
+++ b/pages/download.vue
@@ -4,15 +4,7 @@
 
         <b-row>
 
-            <b-col cols="12">
-                <b-table
-                    bordered
-                    outlined
-                    sticky-header
-                    striped
-                    head-variant="dark"
-                    :items="dataTable.annotated" />
-            </b-col>
+            <!-- Annotated data dictionary preview goes here -->
 
         </b-row>
 
@@ -40,12 +32,6 @@
 
 <script>
 
-    // Allows for reference to store data by creating simple, implicit getters
-    import { mapGetters } from "vuex";
-
-    // Fields listed in mapState below can be found in the store (index.js)
-    import { mapState } from "vuex";
-
     // Saves file to user's computer
     import { saveAs } from "file-saver";
 
@@ -60,6 +46,7 @@
                 jsonSpacing: 4,
 
                 // Size of the file display textboxes
+                // NOTE: Leaving this in for data dictionary preview text box
                 textArea: {
 
                     height: 800,
@@ -75,33 +62,6 @@
         },
 
         computed: {
-            ...mapState([
-
-                "columnToCategoryMap",
-                "dataTable",
-                "missingValueLabel",
-                "toolGroups"
-            ]),
-
-            categoryToColumnMap() {
-
-                // Create a reverse lookup map of the columnToCategory map in the store
-                const categoryToColumnMap = {};
-                for ( const column in this.columnToCategoryMap ) {
-
-                    const category = this.columnToCategoryMap[column];
-
-                    // Categories may have multiple columns associated with them
-                    if ( !Object.keys(categoryToColumnMap).includes(category) ) {
-
-                        categoryToColumnMap[category] = [];
-                    }
-
-                    categoryToColumnMap[category].push(column);
-                }
-
-                return categoryToColumnMap;
-            },
 
             datasetName() {
 
@@ -117,84 +77,34 @@
 
         methods: {
 
+            // NOTE: Commenting out code for downloadAnnotedData and transformAnnotatedJSON for now
+            // Leaving this code in as a reminder what the file saveAs functionality needs
             downloadAnnotatedData() {
 
-                // 1. Format the annotated table into propietary JSON format
-                const jsonData = this.transformAnnotatedTableToJSON();
+                // // 1. Format the annotated table into propietary JSON format
+                // const jsonData = this.transformAnnotatedTableToJSON();
 
-                // 2. Open file dialog to prompt the user to name it and
-                // download it to their location of choice
-                this.fileSaverSaveAs(jsonData);
+                // // 2. Open file dialog to prompt the user to name it and
+                // // download it to their location of choice
+                // this.fileSaverSaveAs(jsonData);
             },
 
             fileSaverSaveAs(p_jsonData) {
 
                 const blob = new Blob([JSON.stringify(p_jsonData, null, this.jsonSpacing)], {type: "text/plain;charset=utf-8"});
                 saveAs(blob, this.defaultOutputFilename);
-            },
-
-            transformAnnotatedRowToSubjectJSON(p_row) {
-
-                // 0. Determine all columns of the original data that have been categorized
-                const availableCategories = Object.values(this.columnToCategoryMap);
-
-                // 1. Create the new subject object, key by key
-                const subjectJSON = {};
-
-                // NOTE: Currently the categories subject ID, age, and sex must be applied to only one column each
-
-                // A. Subject ID - This categorization is required in order to
-                // proceed to the annotation page
-                subjectJSON["label"] = p_row[this.categoryToColumnMap["Subject ID"][0]];
-
-                // B. Age
-                if ( availableCategories.includes("Age") ) {
-
-                    subjectJSON["age"] = p_row[this.categoryToColumnMap["Age"][0]];
-                }
-
-                // C. Sex
-                if ( availableCategories.includes("Sex") ) {
-
-                    subjectJSON["sex"] = p_row[this.categoryToColumnMap["Sex"][0]];
-                }
-
-                // D. Diagnoses
-                if ( availableCategories.includes("Diagnosis") ) {
-
-                    // I. Create a list of values from the diagnosis columns in the annotated table row
-                    subjectJSON["diagnosis"] = this.categoryToColumnMap["Diagnosis"]
-                        .map(column => { return {identifier: p_row[column]}; })
-                        .filter(value => this.missingValueLabel !== value.identifier);
-                }
-
-                // E. Assessment tool group availability for this subject
-                subjectJSON["assessment_tool"] = [];
-                for ( const groupName in this.toolGroups ) {
-
-                    // NOTE: Availability suffix string should be in store?
-                    const column = groupName + "_avail";
-
-                    // Only include tool group names that are available for this subject
-                    if ( true === p_row[column] ) {
-
-                        subjectJSON["assessment_tool"].push(column);
-                    }
-                }
-
-                return subjectJSON;
-            },
-
-            transformAnnotatedTableToJSON() {
-
-                // Transform the annotated data table into a new subject-centric JSON format for the output file
-                return {
-
-                    name: this.datasetName,
-                    type: "dataset",
-                    hasSamples: this.dataTable.annotated.map(row => this.transformAnnotatedRowToSubjectJSON(row))
-                };
             }
+
+            // transformAnnotatedTableToJSON() {
+
+            //     // Transform the annotated data table into a new subject-centric JSON format for the output file
+            //     return {
+
+            //         name: this.datasetName,
+            //         type: "dataset",
+            //         hasSamples: this.dataTable.annotated.map(row => this.transformAnnotatedRowToSubjectJSON(row))
+            //     };
+            // }
         }
     };
 


### PR DESCRIPTION
This PR closes #399 by doing the following:

* The table used to show the former annotated data table has been removed
* Associated methods used to build the JSON for output download have been removed
* Some functionality left in but commented out as a guide for update to new annotated data dictionary download code and possible new preview textbox for the annotated data dictionary
* Code cleanup + updated comments