### PR TITLE
Next page component test

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -23,6 +23,7 @@ jobs:
           spec: |
             cypress/e2e/page/index-pagetests.cy.js
             cypress/e2e/page/categorization-pagetests.cy.js
+            cypress/e2e/page/annotation-pagetests.cy.js
           build: npm run build
           start: npm start
           component: false

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -19,11 +19,6 @@ jobs:
       - name: Run End to End tests 🧪
         uses: cypress-io/github-action@v4
         with:
-          # See https://github.com/cypress-io/github-action#specs for running only certain specs
-          spec: |
-            cypress/e2e/page/index-pagetests.cy.js
-            cypress/e2e/page/categorization-pagetests.cy.js
-            cypress/e2e/page/annotation-pagetests.cy.js
           build: npm run build
           start: npm start
           component: false

--- a/cypress/component/next-page.cy.js
+++ b/cypress/component/next-page.cy.js
@@ -1,0 +1,239 @@
+import nextPage from "~/components/next-page";
+
+let store;
+const pages = ["home", "categorization", "annotation"];
+const uiText = {
+
+    button: {
+
+        "home": "Next step: Categorize columns",
+        "categorization": "Next step: Annotate columns",
+        "annotation": "Next step: Review and download harmonized data"
+    }
+};
+
+describe("next page button", () => {
+
+    beforeEach(() => {
+
+        // Setup
+        store = {
+
+            // commit: (p_mutationName, p_argument) => { store.mutations[p_mutationName](p_argument); },
+            commit: () => {},
+
+            getters: {
+
+                getNextPage: () => {
+
+                    // console.log(`getNextPage called with store.state: ${JSON.stringify(store.state)}`);
+
+                    let nextPage = "";
+
+                    switch ( store.state.currentPage ) {
+
+                        case "home":
+                            nextPage = "categorization";
+                            break;
+                        case "categorization":
+                            nextPage = "annotation";
+                            break;
+                        case "annotation":
+                            nextPage = "download";
+                            break;
+                        case "download":
+                            nextPage = "";
+                            break;
+                    }
+
+                    // console.log(`Next page is ${nextPage}`);
+
+                    return nextPage;
+                },
+
+                isPageAccessible: () => (p_pageName) => {
+
+                    // console.log(`isPageAccessible called for ${p_pageName}`);
+
+                    let pageAccessible = false;
+
+                    switch ( p_pageName ) {
+
+                        case "home":
+
+                            // Landing page is always accessible
+                            pageAccessible = true;
+                            break;
+
+                        case "categorization":
+
+                            // console.log(`dataTable: ${store.state.dataTable}`);
+
+                            // Categorization page is accessible if a data table has been uploaded
+                            pageAccessible = store.state.dataTable.length > 0;
+
+                            break;
+
+                        case "annotation": {
+
+                            // 1. Make sure one (and only one) column has been categorized as 'Subject ID'
+                            const singleSubjectIDColumn = ( 1 === Object.values(store.state.columnToCategoryMap)
+                                                                        .filter(category => "Subject ID" === category)
+                                                                        .length );
+
+                            // 2. Make sure at least one other category other than 'Subject ID' has been linked to a column
+                            const notOnlySubjectIDCategorized = ( Object.values(store.state.columnToCategoryMap)
+                                                                        .filter(category => "Subject ID" !== category &&
+                                                                                null !== category)
+                                                                        .length >= 1 );
+
+                            // Annotation page is only accessible if one (and only one)
+                            // column has been categorized as 'Subject ID' and if at least
+                            // one category other than Subject ID has been categorized
+                            pageAccessible = singleSubjectIDColumn && notOnlySubjectIDCategorized;
+
+                            break;
+                        }
+
+                        case "download":
+
+                            pageAccessible = store.state.annotationCount > 0;
+
+                            break;
+                    }
+
+                    // console.log(`${p_pageName} ${(pageAccessible)? "is" : "is not"} accessible`);
+
+                    return pageAccessible;
+                }
+            },
+
+            mutations: {
+
+                setCurrentPage: () => (p_pageName) => {
+
+                    console.log(`setCurrentPage called for ${p_pageName}`);
+
+                    store.state.currentPage = p_pageName;
+                }
+            },
+
+            state: {
+
+                annotationCount: 0,
+                columnToCategoryMap: {},
+                currentPage: "home",
+                dataTable: [],
+                pageData: {
+
+                    home: {
+
+                        fullName: "Home",
+                        location: "/",
+                        pageName: "home"
+                    },
+
+                    categorization: {
+
+                        fullName: "Categorization",
+                        location: "categorization",
+                        pageName: "categorization"
+                    },
+
+                    annotation: {
+
+                        fullName: "Annotation",
+                        location: "annotation",
+                        pageName: "annotation"
+                    },
+
+                    download: {
+
+                        fullName: "Download",
+                        location: "download",
+                        pageName: "download"
+                    }
+                }
+            }
+        };
+    });
+
+    pages.forEach(pageName => {
+
+        it(`Does the label on next page button correspond to the ${pageName} page`, () => {
+
+            // Setup - Mount the next page button
+            cy.mount(nextPage, {
+
+                computed: store.getters,
+                mocks: { $store: store }
+            });
+
+            // Act - Change current page store field to the desired page
+            store.mutations.setCurrentPage()(pageName);
+
+            // Assert - Check button text corresponds to the recently set page
+            cy.get("[data-cy='button-nextpage']").should("contain", uiText.button[pageName]);
+        });
+    });
+
+    it("Does next page disabled status correspond to page accessibility", () => {
+
+        // Setup - Mount the next page button
+        cy.mount(nextPage, {
+
+            computed: store.getters,
+            mocks: { $store: store }
+        });
+
+        // Assert
+
+        // A. Button is disabled and page is inaccessible
+        cy.get("[data-cy='button-nextpage']").should(($button) => {
+
+            expect($button).to.have.class("disabled");
+            expect(store.getters.isPageAccessible()("categorization")).to.be.false;
+        });
+
+        // B. Button is enabled and page is accessible if data table is loaded
+        cy.get("[data-cy='button-nextpage']").should(($button) => {
+
+            // Setup - Make categorization page accessible
+            store.state.dataTable = ["some data"];
+
+            expect($button).to.not.have.class("disabled");
+            expect(store.getters.isPageAccessible()("categorization")).to.be.true;
+        });
+    });
+
+    it("When clicked is setCurrentPage mutation fired *once* with the correct parameters", () => {
+
+        // Setup
+
+        // A. Spy on the commit function
+        cy.spy(store, "commit").as("commitSpy");
+
+        // B. Mount the next page button
+        cy.mount(nextPage, {
+
+            computed: store.getters,
+            mocks: { $store: store }
+        });
+
+        // C. Store with values for completed home page
+        store.state.currentPage = "home";
+        store.state.dataTable = ["some data"];
+
+        // Act - Click on the next page button
+        cy.get("[data-cy='button-nextpage']")
+          .click()
+          .intercept("/categorization", req => {
+
+            // Do not navigate to categorization page since this is a component test
+            req.destroy();
+
+            // Assert - currentPage mutation has been called with the correct page name
+            cy.get("@commitSpy").should("have.been.calledWith", "setCurrentPage", "categorization");
+          });
+    });
+});

--- a/cypress/e2e/app/simple-e2etest.cy.js
+++ b/cypress/e2e/app/simple-e2etest.cy.js
@@ -37,30 +37,32 @@ describe("End to end test using a simple UI path through the app", () => {
                 ]
             };
 
-            if ( cy.datasetMeetsTestCriteria("annotation", p_dataset, testCriteria) ) {
+            // 1. Go through index page, selecting participants tsv and json dictionary files
 
-                // 1. Go through index page, selecting participants tsv and json dictionary files
+            // A. Assert that categorization nav item and next button are disabled
+            cy.assertNextPageAccess("categorization", false);
 
-                // A. Assert that categorization nav item and next button are disabled
-                cy.assertNextPageAccess("categorization", false);
+            // B. Select data table file
+            cy.get("[data-cy='data-table-selector']")
+                .contains("Choose file")
+                .click()
+                .selectFile(dataFolder + p_dataset.data_table);
 
-                // B. Select data table file
-                cy.get("[data-cy='data-table-selector']")
-                    .contains("Choose file")
-                    .click()
-                    .selectFile(dataFolder + p_dataset.data_table);
+            // C. Assert that categorization nav item and next button are enabled
+            cy.assertNextPageAccess("categorization", true);
 
-                // C. Assert that categorization nav item and next button are enabled
-                cy.assertNextPageAccess("categorization", true);
+            // D. Select participants dictionary
+            cy.get("[data-cy='data-dictionary-selector']")
+                .contains("Choose file")
+                .click()
+                .selectFile(dataFolder + p_dataset.data_dictionary);
 
-                // D. Select participants dictionary
-                cy.get("[data-cy='data-dictionary-selector']")
-                    .contains("Choose file")
-                    .click()
-                    .selectFile(dataFolder + p_dataset.data_dictionary);
+            // E. Click the next page button to proceed to the categorization page
+            cy.nextPageByButton();
 
-                // E. Click the next page button to proceed to the categorization page
-                cy.nextPageByButton();
+            cy.commitToVuexStore("setCurrentPage", "categorization");
+
+            if ( cy.datasetMeetsTestCriteria("categorization", p_dataset, testCriteria) ) {
 
                 // 2. Go through categorization page, categorizing subject ID and age columns in the table
 
@@ -70,44 +72,50 @@ describe("End to end test using a simple UI path through the app", () => {
                 // B. Categorize "participant_id" as "Subject ID"
                 cy.categorizeColumn("Subject ID", p_dataset["category_columns"]["Subject ID"][0]);
 
-                // C. Assert nav and next button are enabled
-                cy.assertNextPageAccess("annotation", true);
+                // C. Assert nav and next button are not yet enabled
+                cy.assertNextPageAccess("annotation", false);
 
                 // D. Categorize "age" as "Age"
                 cy.categorizeColumn("Age", p_dataset["category_columns"]["Age"][0]);
 
+                cy.assertNextPageAccess("annotation", true);
+
                 // E. Click the next page button to proceed to the categorization page
                 cy.nextPageByButton();
 
-                // 3. Go through annotation page, saving default age annotation
+                cy.commitToVuexStore("setCurrentPage", "annotation");
 
-                // A. Assert that next page nav and button are disabled for download page
-                cy.assertNextPageAccess("download", false);
+                if ( cy.datasetMeetsTestCriteria("annotation", p_dataset, testCriteria)) {
 
-                // B. Click on the 'Age' tab
-                cy.get("[data-cy='annotation-category-tabs'] ul")
-                    .contains("li", "Age")
-                    .click();
+                    // 3. Go through annotation page, saving default age annotation
 
-                // C. Click on the 'Save Annotation' button
-                cy.get("button")
-                    .contains("Save Annotation")
-                    .click();
+                    // A. Assert that next page nav and button are disabled for download page
+                    cy.assertNextPageAccess("download", false);
 
-                // D. Assert that next page nav and button are enabled for download page
-                cy.assertNextPageAccess("download", true);
+                    // B. Click on the 'Age' tab
+                    cy.get("[data-cy='annotation-category-tabs'] ul")
+                        .contains("li", "Age")
+                        .click();
 
-                // E. Click the next page button to proceed to the download page
-                cy.nextPageByButton();
+                    // B. Select the 'float' transformation heuristic
+                    // :data-cy="'selectTransform_' + columnName"
+                    cy.get("[data-cy='selectTransform_age']").click().type("float{enter}");
 
-                // 4. Go through the download page, downloading the output annotation file
+                    // D. Assert that next page nav and button are enabled for download page
+                    cy.assertNextPageAccess("download", true);
 
-                // A. Click the download button
-                cy.get("[data-cy='download-button']")
-                    .click();
+                    // E. Click the next page button to proceed to the download page
+                    cy.nextPageByButton();
 
-                // B. Assert that csv file has downloaded
-                // cy.verifyDownload(".json", { contains: true });
+                    // 4. Go through the download page, downloading the output annotation file
+
+                    // A. Click the download button
+                    cy.get("[data-cy='download-button']")
+                        .click();
+
+                    // B. Assert that csv file has downloaded
+                    // cy.verifyDownload(".json", { contains: true });
+                }
             }
         });
     });

--- a/cypress/e2e/app/simple-e2etest.cy.js
+++ b/cypress/e2e/app/simple-e2etest.cy.js
@@ -73,11 +73,15 @@ describe("End to end test using a simple UI path through the app", () => {
                 cy.categorizeColumn("Subject ID", p_dataset["category_columns"]["Subject ID"][0]);
 
                 // C. Assert nav and next button are not yet enabled
+                // For annotation page to be enabled, subject ID and
+                // at least one other column must be categorized.
                 cy.assertNextPageAccess("annotation", false);
 
                 // D. Categorize "age" as "Age"
                 cy.categorizeColumn("Age", p_dataset["category_columns"]["Age"][0]);
 
+                // Since Age and subject ID have been categorized
+                // annotation page is no accessible.
                 cy.assertNextPageAccess("annotation", true);
 
                 // E. Click the next page button to proceed to the categorization page
@@ -98,7 +102,7 @@ describe("End to end test using a simple UI path through the app", () => {
                         .click();
 
                     // B. Select the 'float' transformation heuristic
-                    // :data-cy="'selectTransform_' + columnName"
+                    // :data-cy="'selectTransform_' + columnName" where columnName is age
                     cy.get("[data-cy='selectTransform_age']").click().type("float{enter}");
 
                     // D. Assert that next page nav and button are enabled for download page

--- a/cypress/e2e/page/annotation-pagetests.cy.js
+++ b/cypress/e2e/page/annotation-pagetests.cy.js
@@ -35,13 +35,18 @@ describe("tests on annotation page ui with programmatic state loading and store 
                 cy.loadTestDataIntoStore(p_dataset);
 
                 // 3. Move to the annotation page
-                cy.window().its("$nuxt.$router").then(router => {
+                // cy.window().its("$nuxt.$router").then(router => {
 
-                    router.push({ path: "/annotation" });
-                });
+                //     router.push({ path: "/annotation" });
+                // });
             });
 
-            it("Annotate age column; default age format transformations", () => {
+            it.only("Annotate age column; default age format transformations", () => {
+
+                console.log("Start of test store:");
+                cy.window().its("$nuxt.$store").then(p_store => {
+                    console.dir(p_store);
+                });
 
                 // 0. Categories required for this test and the number of required columns for each category
                 const testCriteria = {
@@ -58,10 +63,12 @@ describe("tests on annotation page ui with programmatic state loading and store 
                     // 1. Load the app with test criteria using the dataset
                     cy.loadAppState("annotation", p_dataset, testCriteria);
 
+                    cy.visit("/annotation");
+
                     // 2. Pause until 'Age' tab (the default annotation tab) components are loaded
                     // NOTE: This DOM check is possible because the annotation tool uses server-side rendering
                     // See https://docs.cypress.io/guides/core-concepts/conditional-testing#Server-side-rendering
-                    cy.get("[data-cy='annot-component-Age']").should("be.visible");
+                    cy.get("[data-cy='annot-continuous-values-age']").should("be.visible");
 
                     // 3. Assert annotation nav and next page button are disabled
                     cy.assertNextPageAccess("download", false);
@@ -73,9 +80,9 @@ describe("tests on annotation page ui with programmatic state loading and store 
                         .contains("li", "Age")
                         .click();
 
-                    // B. Click on the 'Save Annotation' button
-                    cy.get("[data-cy='save-button-Age']")
-                        .click();
+                    // B. Select the 'float' transformation heuristic
+                    // :data-cy="'selectTransform_' + columnName"
+                    cy.get("[data-cy='selectTransform_age']").click().type("float{enter}");
 
                     // 5. Assert annotation nav and next page button are enabled
                     cy.assertNextPageAccess("download", true);

--- a/cypress/e2e/page/annotation-pagetests.cy.js
+++ b/cypress/e2e/page/annotation-pagetests.cy.js
@@ -37,14 +37,17 @@ describe("tests on annotation page ui with programmatic state loading and store 
                 // 3. Move to the annotation page
                 cy.window().its("$nuxt.$router").then(router => {
 
+                    // A. Route to annotation page
                     router.push({ path: "/annotation" });
+
+                    // B. Once routing is complete, set the current page in the nuxt store
+                    // (normally would happen via navigation clicks)
                     cy.commitToVuexStore("setCurrentPage", "annotation");
                 });
             });
 
             it("Annotate age column; default age format transformations", () => {
 
-                console.log("Start of test store:");
                 cy.window().its("$nuxt.$store").then(p_store => {
                     console.dir(p_store);
                 });
@@ -63,8 +66,6 @@ describe("tests on annotation page ui with programmatic state loading and store 
 
                     // 1. Load the app with test criteria using the dataset
                     cy.loadAppState("annotation", p_dataset, testCriteria);
-
-                    // cy.visit("/annotation");
 
                     // 2. Pause until 'Age' tab (the default annotation tab) components are loaded
                     // NOTE: This DOM check is possible because the annotation tool uses server-side rendering

--- a/cypress/e2e/page/annotation-pagetests.cy.js
+++ b/cypress/e2e/page/annotation-pagetests.cy.js
@@ -38,10 +38,11 @@ describe("tests on annotation page ui with programmatic state loading and store 
                 cy.window().its("$nuxt.$router").then(router => {
 
                     router.push({ path: "/annotation" });
+                    cy.commitToVuexStore("setCurrentPage", "annotation");
                 });
             });
 
-            it.only("Annotate age column; default age format transformations", () => {
+            it("Annotate age column; default age format transformations", () => {
 
                 console.log("Start of test store:");
                 cy.window().its("$nuxt.$store").then(p_store => {
@@ -106,10 +107,10 @@ describe("tests on annotation page ui with programmatic state loading and store 
                     // 1. Load the app with test criteria using the dataset
                     cy.loadAppState("annotation", p_dataset, testCriteria);
 
-                    // 2. Pause until 'Age' tab (the default annotation tab) components are loaded
+                    // 2. Pause until 'Sex' tab (the default annotation tab) components are loaded
                     // NOTE: This DOM check is possible because the annotation tool uses server-side rendering
                     // See https://docs.cypress.io/guides/core-concepts/conditional-testing#Server-side-rendering
-                    cy.get("[data-cy='annot-component-Age']").should("be.visible");
+                    cy.get("[data-cy='annot-categorical-Sex']").should("be.visible");
 
                     // 3. Assert annotation nav and next page button are disabled
                     cy.assertNextPageAccess("download", false);
@@ -122,12 +123,8 @@ describe("tests on annotation page ui with programmatic state loading and store 
                         .click();
 
                     // B. Select annotation choices for 'Sex' column values
-                    cy.get("[data-cy='discrete-select-Sex-0']").click().type("male{enter}");
-                    cy.get("[data-cy='discrete-select-Sex-1']").click().type("female{enter}");
-
-                    // C. Click on the 'Save Annotation' button
-                    cy.get("[data-cy='save-button-Sex']")
-                        .click();
+                    cy.get("[data-cy='categoricalSelector_0']").click().type("male{enter}");
+                    cy.get("[data-cy='categoricalSelector_1']").click().type("female{enter}");
 
                     // 5. Assert annotation nav and next page button are enabled
                     cy.assertNextPageAccess("download", true);
@@ -154,7 +151,7 @@ describe("tests on annotation page ui with programmatic state loading and store 
                     // 2. Pause until 'Age' tab (the default annotation tab) components are loaded
                     // NOTE: This DOM check is possible because the annotation tool uses server-side rendering
                     // See https://docs.cypress.io/guides/core-concepts/conditional-testing#Server-side-rendering
-                    cy.get("[data-cy='annot-component-Age']").should("be.visible");
+                    cy.get("[data-cy='annot-categorical-Diagnosis']").should("be.visible");
 
                     // 3. Assert annotation nav and next page button are disabled
                     cy.assertNextPageAccess("download", false);
@@ -168,192 +165,184 @@ describe("tests on annotation page ui with programmatic state loading and store 
 
                     // B. Enter annotated values for each unique value in the 'Diagnosis'-categorized column
                     // NOTE: This value of '3' should be pulled from the interface via the number of unique diagnosis values returned
-                    const uniqueValueCount = 3;
-                    for ( let index = 0; index < uniqueValueCount; index++ ) {
-
-                        cy.get("[data-cy='vocab-term-Diagnosis-" + parseInt(index) + "']")
-                            .click()
-                            .type("Annotated value " +  parseInt(index));
-                    }
-
-                    // C. Click on the 'Save Annotation' button
-                    cy.get("[data-cy='save-button-Diagnosis']")
-                        .click();
+                    cy.get("[data-cy='categoricalSelector_0']").click().type("Depressive{enter}");
+                    cy.get("[data-cy='categoricalSelector_1']").click().type("Parkins{enter}");
+                    cy.get("[data-cy='categoricalSelector_2']").click().type("Other{enter}");
 
                     // 5. Assert annotation nav and next page button are enabled
                     cy.assertNextPageAccess("download", true);
                 }
             });
 
-            it("Annotate single tool group with single assessment tool column; no missing values", () => {
+            // it("Annotate single tool group with single assessment tool column; no missing values", () => {
 
                 // 0. Categories and tool groups required for this test and the number of required columns for each category
-                const testCriteria = {
+                // const testCriteria = {
 
-                    categories: [
+                //     categories: [
 
-                        ["Subject ID", 1],
-                        ["Diagnosis", 1],
-                        ["Assessment Tool", 1]
-                    ],
+                //         ["Subject ID", 1],
+                //         ["Diagnosis", 1],
+                //         ["Assessment Tool", 1]
+                //     ],
 
-                    toolGroups: [
+                //     toolGroups: [
 
-                        ["My Tool Group", 1]
-                    ]
-                };
+                //         ["My Tool Group", 1]
+                //     ]
+                // };
 
-                if ( cy.datasetMeetsTestCriteria("annotation", p_dataset, testCriteria) ) {
+                // if ( cy.datasetMeetsTestCriteria("annotation", p_dataset, testCriteria) ) {
 
                     // 1. Load the app with test criteria using the dataset
-                    cy.loadAppState("annotation", p_dataset, testCriteria);
+                    // cy.loadAppState("annotation", p_dataset, testCriteria);
 
                     // 2. Pause until 'Age' tab (the default annotation tab) components are loaded
                     // NOTE: This DOM check is possible because the annotation tool uses server-side rendering
                     // See https://docs.cypress.io/guides/core-concepts/conditional-testing#Server-side-rendering
-                    cy.get("[data-cy='annot-component-Age']").should("be.visible");
+                    // cy.get("[data-cy='annot-component-Age']").should("be.visible");
 
                     // 3. Assert annotation nav and next page button are disabled
-                    cy.assertNextPageAccess("download", false);
+                    // cy.assertNextPageAccess("download", false);
 
                     // 4. Annotate 'Assessment Tool'-categorized column
 
                     // A. Click on the tool group's tab
-                    cy.get("[data-cy='annotation-category-tabs'] ul")
-                        .contains("li", testCriteria.toolGroups[0][0])
-                        .click();
+                    // cy.get("[data-cy='annotation-category-tabs'] ul")
+                    //     .contains("li", testCriteria.toolGroups[0][0])
+                    //     .click();
 
                     // B. Pause until assessment tool group tabbed table is visible
-                    cy.get(`[data-cy='annot-tool-group-table-${testCriteria.toolGroups[0][0]}']`).should("be.visible");
+                    // cy.get(`[data-cy='annot-tool-group-table-${testCriteria.toolGroups[0][0]}']`).should("be.visible");
 
                     // C. Click on the 'Save Annotation' button
-                    cy.get(`[data-cy='save-button-${testCriteria.toolGroups[0][0]}']`)
-                        .click();
+                    // cy.get(`[data-cy='save-button-${testCriteria.toolGroups[0][0]}']`)
+                        // .click();
 
                     // 5. Assert annotation nav and next page button are enabled
-                    cy.assertNextPageAccess("download", true);
-                }
-            });
+            //         cy.assertNextPageAccess("download", true);
+            //     }
+            // });
 
-            it("Annotate single tool group with multi-assessment tool column; no missing values", () => {
+            // it("Annotate single tool group with multi-assessment tool column; no missing values", () => {
 
                 // 0. Categories and tool groups required for this test and the number of required columns for each category
-                const testCriteria = {
+                // const testCriteria = {
 
-                    categories: [
+                //     categories: [
 
-                        ["Subject ID", 1],
-                        ["Age", 1],
-                        ["Assessment Tool", 2]
-                    ],
+                //         ["Subject ID", 1],
+                //         ["Age", 1],
+                //         ["Assessment Tool", 2]
+                //     ],
 
-                    toolGroups: [
+                //     toolGroups: [
 
-                        ["My Tool Group", 2]
-                    ]
-                };
+                //         ["My Tool Group", 2]
+                //     ]
+                // };
 
-                if ( cy.datasetMeetsTestCriteria("annotation", p_dataset, testCriteria) ) {
+                // if ( cy.datasetMeetsTestCriteria("annotation", p_dataset, testCriteria) ) {
 
                     // 1. Load the app with test criteria using the dataset
-                    cy.loadAppState("annotation", p_dataset, testCriteria);
+                    // cy.loadAppState("annotation", p_dataset, testCriteria);
 
                     // 2. Pause until 'Age' tab (the default annotation tab) components are loaded
                     // NOTE: This DOM check is possible because the annotation tool uses server-side rendering
                     // See https://docs.cypress.io/guides/core-concepts/conditional-testing#Server-side-rendering
-                    cy.get("[data-cy='annot-component-Age']").should("be.visible");
+                    // cy.get("[data-cy='annot-component-Age']").should("be.visible");
 
                     // 3. Assert annotation nav and next page button are disabled
-                    cy.assertNextPageAccess("download", false);
+                    // cy.assertNextPageAccess("download", false);
 
                     // 4. Annotate the 'Assessment Tool'-categorized column
 
                     // A. Click on the tool group's tab
-                    cy.get("[data-cy='annotation-category-tabs'] ul")
-                        .contains("li", testCriteria.toolGroups[0][0])
-                        .click();
+                    // cy.get("[data-cy='annotation-category-tabs'] ul")
+                    //     .contains("li", testCriteria.toolGroups[0][0])
+                    //     .click();
 
                     // B. Pause until assessment tool group tabbed table is visible
-                    cy.get(`[data-cy='annot-tool-group-table-${testCriteria.toolGroups[0][0]}']`).should("be.visible");
+                    // cy.get(`[data-cy='annot-tool-group-table-${testCriteria.toolGroups[0][0]}']`).should("be.visible");
 
                     // C. Click on the 'Save Annotation' button
-                    cy.get(`[data-cy='save-button-${testCriteria.toolGroups[0][0]}']`)
-                        .click();
+                    // cy.get(`[data-cy='save-button-${testCriteria.toolGroups[0][0]}']`)
+                    //     .click();
 
                     // 5. Assert annotation nav and next page button are enabled
-                    cy.assertNextPageAccess("download", true);
-                }
-            });
+                    // cy.assertNextPageAccess("download", true);
+            //     }
+            // });
 
-            it("Annotate two tool groups with single assessment tool column; no missing values", () => {
+            // it("Annotate two tool groups with single assessment tool column; no missing values", () => {
 
                 // 0. Categories and tool groups required for this test and the number of required columns for each category
-                const testCriteria = {
+                // const testCriteria = {
 
-                    categories: [
+                //     categories: [
 
-                        ["Subject ID", 1],
-                        ["Age", 1],
-                        ["Sex", 1],
-                        ["Diagnosis", 1],
-                        ["Assessment Tool", 2]
-                    ],
+                //         ["Subject ID", 1],
+                //         ["Age", 1],
+                //         ["Sex", 1],
+                //         ["Diagnosis", 1],
+                //         ["Assessment Tool", 2]
+                //     ],
 
-                    toolGroups: [
+                //     toolGroups: [
 
-                        ["My Tool Group", 1],
-                        ["My Other Tool Group", 1]
-                    ]
-                };
+                //         ["My Tool Group", 1],
+                //         ["My Other Tool Group", 1]
+                //     ]
+                // };
 
-                if ( cy.datasetMeetsTestCriteria("annotation", p_dataset, testCriteria) ) {
+                // if ( cy.datasetMeetsTestCriteria("annotation", p_dataset, testCriteria) ) {
 
                     // 1. Load the app with test criteria using the dataset
-                    cy.loadAppState("annotation", p_dataset, testCriteria);
+                    // cy.loadAppState("annotation", p_dataset, testCriteria);
 
                     // 2. Pause until 'Age' tab (the default annotation tab) components are loaded
                     // NOTE: This DOM check is possible because the annotation tool uses server-side rendering
                     // See https://docs.cypress.io/guides/core-concepts/conditional-testing#Server-side-rendering
-                    cy.get("[data-cy='annot-component-Age']").should("be.visible");
+                    // cy.get("[data-cy='annot-component-Age']").should("be.visible");
 
                     // 3. Assert annotation nav and next page button are disabled
-                    cy.assertNextPageAccess("download", false);
+                    // cy.assertNextPageAccess("download", false);
 
                     // 4. Annotate the the first 'Assessment Tool'-categorized column
 
                     // A. Click on the first tool group's tab
-                    cy.get("[data-cy='annotation-category-tabs'] ul")
-                        .contains("li", testCriteria.toolGroups[0][0])
-                        .click();
+                    // cy.get("[data-cy='annotation-category-tabs'] ul")
+                        // .contains("li", testCriteria.toolGroups[0][0])
+                        // .click();
 
                     // B. Pause until assessment tool group tabbed table is visible
-                    cy.get(`[data-cy='annot-tool-group-table-${testCriteria.toolGroups[0][0]}']`).should("be.visible");
+                    // cy.get(`[data-cy='annot-tool-group-table-${testCriteria.toolGroups[0][0]}']`).should("be.visible");
 
                     // C. Click on the 'Save Annotation' button
-                    cy.get(`[data-cy='save-button-${testCriteria.toolGroups[0][0]}']`)
-                        .click();
+                    // cy.get(`[data-cy='save-button-${testCriteria.toolGroups[0][0]}']`)
+                    //     .click();
 
                     // 5. Assert annotation nav and next page button is enabled
-                    cy.assertNextPageAccess("download", true);
+                    // cy.assertNextPageAccess("download", true);
 
                     // 6. Annotate the the second 'Assessment Tool'-categorized column
 
                     // A. Click on the first tool group's tab
-                    cy.get("[data-cy='annotation-category-tabs'] ul")
-                        .contains("li", testCriteria.toolGroups[1][0])
-                        .click();
+                    // cy.get("[data-cy='annotation-category-tabs'] ul")
+                    //     .contains("li", testCriteria.toolGroups[1][0])
+                    //     .click();
 
                     // B. Pause until the second assessment tool group tabbed table is visible
-                    cy.get(`[data-cy='annot-tool-group-table-${testCriteria.toolGroups[1][0]}']`).should("be.visible");
+                    // cy.get(`[data-cy='annot-tool-group-table-${testCriteria.toolGroups[1][0]}']`).should("be.visible");
 
                     // C. Click on the 'Save Annotation' button
-                    cy.get(`[data-cy='save-button-${testCriteria.toolGroups[1][0]}']`)
-                        .click();
+                    // cy.get(`[data-cy='save-button-${testCriteria.toolGroups[1][0]}']`)
+                        // .click();
 
                     // 7. Assert annotation nav and next page button is still enabled
-                    cy.assertNextPageAccess("download", true);
-                }
-            });
+    //                 cy.assertNextPageAccess("download", true);
+    //             }
+    //         });
         });
     });
 });

--- a/cypress/e2e/page/annotation-pagetests.cy.js
+++ b/cypress/e2e/page/annotation-pagetests.cy.js
@@ -35,10 +35,10 @@ describe("tests on annotation page ui with programmatic state loading and store 
                 cy.loadTestDataIntoStore(p_dataset);
 
                 // 3. Move to the annotation page
-                // cy.window().its("$nuxt.$router").then(router => {
+                cy.window().its("$nuxt.$router").then(router => {
 
-                //     router.push({ path: "/annotation" });
-                // });
+                    router.push({ path: "/annotation" });
+                });
             });
 
             it.only("Annotate age column; default age format transformations", () => {
@@ -63,12 +63,12 @@ describe("tests on annotation page ui with programmatic state loading and store 
                     // 1. Load the app with test criteria using the dataset
                     cy.loadAppState("annotation", p_dataset, testCriteria);
 
-                    cy.visit("/annotation");
+                    // cy.visit("/annotation");
 
                     // 2. Pause until 'Age' tab (the default annotation tab) components are loaded
                     // NOTE: This DOM check is possible because the annotation tool uses server-side rendering
                     // See https://docs.cypress.io/guides/core-concepts/conditional-testing#Server-side-rendering
-                    cy.get("[data-cy='annot-continuous-values-age']").should("be.visible");
+                    cy.get("[data-cy='annot-continuous-values-Age']").should("be.visible");
 
                     // 3. Assert annotation nav and next page button are disabled
                     cy.assertNextPageAccess("download", false);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -95,23 +95,6 @@ Cypress.Commands.add("datasetMeetsTestCriteria", (p_pageName, p_datasetConfig, p
             else if ( columnCount > p_datasetConfig["category_columns"][category].length )
                 return false;
         }
-
-        // 2. Check to see if the tool group categorization requirements of a test are met by a dataset
-        if ( "toolGroups" in p_testCriteria ) {
-
-            // A. Failure #1: Dataset does not have an 'Assessment Tool' category
-            if ( !Object.keys(p_datasetConfig["category_columns"]).includes("Assessment Tool") )
-                return false;
-
-            // B. Failure #2: Test tool count requirement is more than the # of tools available in dataset
-            const datasetToolCount = p_datasetConfig["category_columns"]["Assessment Tool"].length;
-            let testToolCount = 0;
-            for ( const [/*groupName*/, columnCount] of p_testCriteria.toolGroups ) {
-                testToolCount += columnCount;
-            }
-            if ( testToolCount > datasetToolCount )
-                return false;
-        }
     }
 
     return true;
@@ -161,38 +144,10 @@ Cypress.Commands.add("loadAppState", (p_pageName, p_dataset, p_pageData) => {
             for ( let index = 0; index < columnCount; index++ ) {
 
                 // A. Link the column to this category
-                cy.dispatchToVuexStore("alterColumnCategoryRelation", {
+                cy.dispatchToVuexStore("alterColumnCategoryMapping", {
 
                     category: category,
                     column: p_dataset["category_columns"][category][index]
-                });
-            }
-        }
-
-        // 2. Create assessment tool groups if given
-        if ( "toolGroups" in p_pageData ) {
-
-            const toolGroupData = {};
-
-            // A. For each tool group, create a list of tools from the dataset for each tool group
-            for ( let index = 0; index < p_pageData.toolGroups.length; index++ ) {
-
-                const [groupName, columnCount] = p_pageData.toolGroups[index];
-
-                toolGroupData[groupName] = [];
-                for ( let index = 0; index < p_dataset["category_columns"]["Assessment Tool"].length; index += columnCount + 1) {
-
-                    toolGroupData[groupName] = p_dataset["category_columns"]["Assessment Tool"].slice(index, index + columnCount);
-                }
-            }
-
-            // B. Add each tool group to the store
-            for ( const groupName in toolGroupData ) {
-
-                cy.dispatchToVuexStore("createToolGroup", {
-
-                    name: groupName,
-                    tools: toolGroupData[groupName]
                 });
             }
         }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -103,10 +103,15 @@ Cypress.Commands.add("datasetMeetsTestCriteria", (p_pageName, p_datasetConfig, p
 // Calls mutation in the Nuxt store
 Cypress.Commands.add("commitToVuexStore", (p_mutation, p_data) => {
 
+    console.log(`In commitToVuexStore for ${p_mutation} with data: ${JSON.stringify(p_data)}`);
+
     // Commit mutation with given data on the Nuxt store
     cy.window().its("$nuxt.$store").then(p_store => {
 
         p_store.commit(p_mutation, p_data);
+
+        console.log("Post commit store:");
+        console.dir(p_store);
     });
 });
 
@@ -144,10 +149,10 @@ Cypress.Commands.add("loadAppState", (p_pageName, p_dataset, p_pageData) => {
             for ( let index = 0; index < columnCount; index++ ) {
 
                 // A. Link the column to this category
-                cy.dispatchToVuexStore("alterColumnCategoryMapping", {
+                cy.commitToVuexStore("alterColumnCategoryMapping", {
 
                     category: category,
-                    column: p_dataset["category_columns"][category][index]
+                    columnName: p_dataset["category_columns"][category][index]
                 });
             }
         }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -103,15 +103,10 @@ Cypress.Commands.add("datasetMeetsTestCriteria", (p_pageName, p_datasetConfig, p
 // Calls mutation in the Nuxt store
 Cypress.Commands.add("commitToVuexStore", (p_mutation, p_data) => {
 
-    console.log(`In commitToVuexStore for ${p_mutation} with data: ${JSON.stringify(p_data)}`);
-
     // Commit mutation with given data on the Nuxt store
     cy.window().its("$nuxt.$store").then(p_store => {
 
         p_store.commit(p_mutation, p_data);
-
-        console.log("Post commit store:");
-        console.dir(p_store);
     });
 });
 

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -79,7 +79,8 @@
 
             ...mapState([
 
-                "colorInfo"
+                "colorInfo",
+                "columnToCategoryMap"
             ])
         }
     };

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -65,6 +65,11 @@
             };
         },
 
+        mounted() {
+
+            console.log(`mappedCategories in annotation.vue mount(): ${JSON.stringify(this.columnToCategoryMap)}`);
+        },
+
         computed: {
 
             ...mapGetters([

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -65,11 +65,6 @@
             };
         },
 
-        mounted() {
-
-            console.log(`mappedCategories in annotation.vue mount(): ${JSON.stringify(this.columnToCategoryMap)}`);
-        },
-
         computed: {
 
             ...mapGetters([
@@ -79,8 +74,7 @@
 
             ...mapState([
 
-                "colorInfo",
-                "columnToCategoryMap"
+                "colorInfo"
             ])
         }
     };

--- a/store/index.js
+++ b/store/index.js
@@ -21,6 +21,11 @@ export const state = () => ({
             { label: "male", identifier: "bids:male" },
             { label: "female", identifier: "bids:female" },
             { label: "other", identifier: "bids:other" }
+        ],
+        "Diagnosis": [
+            { label: "Depressive disorder", identifier: "snomed:35489007"},
+            { label: "Parkinson's disease", identifier: "snomed:49049000"},
+            { label: "other", identifier: "snomed:other"}
         ]
     },
 


### PR DESCRIPTION
This PR closes #412.

As mentioned in the issue, the following tests have now been implemented for the `next-page` component:

* Does the label on next page button correspond to the current page (This is tested across `home`, `categorization`, and `annotation` pages – where a 'next page' button exists.)
* Does next page disabled status correspond to page accessibility
* When clicked is setCurrentPage mutation fired *once* with the correct parameters