### PR TITLE
Getter for json output for discrete (categorical) value columns

### DIFF
--- a/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
+++ b/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
@@ -8,7 +8,6 @@ let store = {
 
     state: {
 
-        appSetting: { termURLPrefix: "prefix" },
         categoricalOptions: {
 
             category1: [
@@ -16,6 +15,14 @@ let store = {
                 { label: "annotatedValue1", identifier: "https://example.org/option_1"},
                 { label: "annotatedValue2", identifier: "https://example.org/option_2"}
             ]
+        },
+        categories: {
+            "category1": {
+
+                componentName: "annot-categorical",
+                explanation: "This is an explanation for how to annotate category1.",
+                identifier: "nb:hasCategory1"
+            }
         },
         columnToCategoryMap: { column1: "category1" },
         dataDictionary: {
@@ -69,9 +76,7 @@ describe("getCategoricalJsonOutput", () => {
 
         // Assert - TermURL in this column's 'IsAbout' section is properly formatted
         // with prefix, colon, and capitalized term
-        expect(output.Annotations.IsAbout.TermURL).to.equal(
-            store.state.appSetting.termURLPrefix + ":"
-            + category[0].toUpperCase() + category.substring(1));
+        expect(output.Annotations.IsAbout.TermURL).to.equal("nb:hasCategory1");
     });
 
     it("Make sure 'Levels' contains correctly transformed value map data from the store's annotated data dictionary", () => {

--- a/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
+++ b/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
@@ -1,5 +1,7 @@
 import { getters } from "~/store";
 
+const category = "category1";
+const columnName = "column1";
 let store = {
 
     getters: getters,
@@ -10,18 +12,18 @@ let store = {
         categoricalOptions: {
 
             category1: [
+
                 { label: "annotatedValue1", identifier: "https://example.org/option_1"},
                 { label: "annotatedValue2", identifier: "https://example.org/option_2"}
             ]
         },
-        columnToCategoryMap: {
-
-            column1: "category1"
-        },
-
+        columnToCategoryMap: { column1: "category1" },
         dataDictionary: {
+
             annotated: {
+
                 column1: {
+
                     valueMap: { "rawValue1": "annotatedValue1" }
                 }
             }
@@ -31,9 +33,7 @@ let store = {
 
 describe("getCategoricalJsonOutput", () => {
 
-    it.skip("Make sure categorical json output is schema compliant", () => {
-
-        let columnName = "column1";
+    it("Make sure categorical json output is schema compliant", () => {
 
         // Act - Get formatted json output data for discrete value column
         const output = store.getters.getCategoricalJsonOutput(store.state)(columnName);
@@ -61,9 +61,6 @@ describe("getCategoricalJsonOutput", () => {
 
     it("Make sure 'IsAbout' fields are properly formatted", () => {
 
-        let columnName = "column1";
-        let category = "category1";
-
         // Act - Get formatted json output data for discrete value column
         const output = store.getters.getCategoricalJsonOutput(store.state)(columnName);
 
@@ -78,8 +75,6 @@ describe("getCategoricalJsonOutput", () => {
     });
 
     it("Make sure 'Levels' contains correctly transformed value map data from the store's annotated data dictionary", () => {
-
-        let columnName = "column1";
 
         // Act - Get formatted json output data for discrete value column
         const output = store.getters.getCategoricalJsonOutput(store.state)(columnName);

--- a/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
+++ b/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
@@ -31,7 +31,7 @@ let store = {
 
                 column1: {
 
-                    valueMap: { "rawValue1": "annotatedValue1" }
+                    valueMap: { "rawValue1": "https://example.org/option_1" }
                 }
             }
         }
@@ -88,12 +88,11 @@ describe("getCategoricalJsonOutput", () => {
         expect(Object.keys(output.Annotations.Levels)).to.deep.equal(
             Object.keys(store.state.dataDictionary.annotated[columnName].valueMap));
 
-        // Assert - Labels in each object in 'Levels' should match annotated value from the
+        // Assert - Labels in each object in 'Levels' should match label from the
         // store's annotated data dictionary value map
         Object.keys(output.Annotations.Levels).forEach(rawValue => {
 
-            expect(output.Annotations.Levels[rawValue].Label).to.equal(
-                store.state.dataDictionary.annotated[columnName].valueMap[rawValue]);
+            expect(output.Annotations.Levels[rawValue].Label).to.equal("annotatedValue1");
         });
     });
 });

--- a/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
+++ b/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
@@ -1,7 +1,5 @@
 import { getters } from "~/store";
 
-const category = "category1";
-const columnName = "column1";
 let store = {
 
     getters: getters,
@@ -32,7 +30,7 @@ let store = {
                 column1: {
 
                     valueMap: { "rawValue1": "https://example.org/option_1" },
-                    missingValues: {0: "missing"}
+                    missingValues: ["missing"]
                 }
             }
         }
@@ -44,37 +42,35 @@ describe("getCategoricalJsonOutput", () => {
     it("Make sure categorical json output is schema compliant", () => {
 
         // Act - Get formatted json output data for discrete value column
-        const output = store.getters.getCategoricalJsonOutput(store.state)(columnName);
+        const output = store.getters.getCategoricalJsonOutput(store.state)("column1");
 
         // Assert - Current annotated data dictionary schema compliance
+        expect(output).to.deep.equal(
+            {
 
-        // Parent level
-
-        expect(output).to.have.property("Annotations");
-
-        // Child level
-
-        expect(output.Annotations).to.have.property("IsAbout");
-        expect(output.Annotations).to.have.property("Levels");
-        expect(output.Annotations).to.have.property("MissingValues");
-
-        // Grandchild level
-        expect(output.Annotations.IsAbout).to.have.property("Label");
-        expect(output.Annotations.IsAbout).to.have.property("TermURL");
-        Object.keys(output.Annotations.Levels).forEach(rawValue => {
-
-            expect(output.Annotations.Levels[rawValue]).to.have.property("Label");
-            expect(output.Annotations.Levels[rawValue]).to.have.property("TermURL");
+                Annotations: {
+                    IsAbout: {
+                        Label: "category1",
+                        TermURL: "nb:hasCategory1"
+                    },
+                    Levels: {
+                        rawValue1: {
+                            Label: "annotatedValue1",
+                            TermURL: "https://example.org/option_1"
+                        }
+                    },
+                    MissingValues: ["missing"]
+                }
         });
     });
 
     it("Make sure 'IsAbout' fields are properly formatted", () => {
 
         // Act - Get formatted json output data for discrete value column
-        const output = store.getters.getCategoricalJsonOutput(store.state)(columnName);
+        const output = store.getters.getCategoricalJsonOutput(store.state)("column1");
 
         // Assert - Label in this column's 'IsAbout' section to be its assigned category
-        expect(output.Annotations.IsAbout.Label).to.equal(category);
+        expect(output.Annotations.IsAbout.Label).to.equal("category1");
 
         // Assert - TermURL in this column's 'IsAbout' section is properly formatted
         // with prefix, colon, and capitalized term
@@ -84,23 +80,20 @@ describe("getCategoricalJsonOutput", () => {
     it("Make sure 'Levels' contains correctly transformed value map data from the store's annotated data dictionary", () => {
 
         // Act - Get formatted json output data for discrete value column
-        const output = store.getters.getCategoricalJsonOutput(store.state)(columnName);
+        const output = store.getters.getCategoricalJsonOutput(store.state)("column1");
 
         // Assert - Keys in 'Levels' are raw values from the value map
         expect(Object.keys(output.Annotations.Levels)).to.deep.equal(
-            Object.keys(store.state.dataDictionary.annotated[columnName].valueMap));
+            Object.keys(store.state.dataDictionary.annotated["column1"].valueMap));
 
         // Assert - Labels in each object in 'Levels' should match label from the
         // store's annotated data dictionary value map
-        Object.keys(output.Annotations.Levels).forEach(rawValue => {
-
-            expect(output.Annotations.Levels[rawValue].Label).to.equal("annotatedValue1");
-        });
+        expect(output.Annotations.Levels["rawValue1"].Label).to.equal("annotatedValue1");
     });
 
     it("Make sure 'MissingValues' is the same as 'missingValues' from annotated data dictionary ", () => {
-        const output = store.getters.getCategoricalJsonOutput(store.state)(columnName);
+        const output = store.getters.getCategoricalJsonOutput(store.state)("column1");
 
-        expect(Object.keys(output.Annotations.MissingValues)).to.deep.equal(Object.keys(["missing"]));
+        expect(output.Annotations.MissingValues).to.deep.equal(["missing"]);
     });
 });

--- a/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
+++ b/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
@@ -1,0 +1,40 @@
+import { getters } from "~/store";
+
+let store = {
+
+    getters: getters,
+
+    state: {
+
+        appSetting: { termURLPrefix: "prefix" },
+        categoricalOptions: {
+
+            "category1": [
+                { label: "option_0", identifier: "https://example.org/option_0"},
+                { label: "option_1", identifier: "https://example.org/option_1"}
+            ]
+        },
+        columnToCategoryMap: {
+
+            "column1": "category1"
+        },
+
+        dataDictionary: {
+            annotated: {
+                valueMap: { "rawValue1": "annotatedValue1" }
+            }
+        }
+    }
+};
+
+describe("getCategoricalJsonOutput", () => {
+
+    it("IsAbout test", () => {
+
+        store = {};
+    });
+
+    it("Levels test", () => {
+
+    });
+});

--- a/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
+++ b/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
@@ -101,6 +101,6 @@ describe("getCategoricalJsonOutput", () => {
     it("Make sure 'MissingValues' is the same as 'missingValues' from annotated data dictionary ", () => {
         const output = store.getters.getCategoricalJsonOutput(store.state)(columnName);
 
-        expect(Object.keys(output.Annotations.MissingValues)).to.deep.equal(Object.keys({0: "missing"}));
+        expect(Object.keys(output.Annotations.MissingValues)).to.deep.equal(Object.keys(["missing"]));
     });
 });

--- a/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
+++ b/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
@@ -9,19 +9,21 @@ let store = {
         appSetting: { termURLPrefix: "prefix" },
         categoricalOptions: {
 
-            "category1": [
-                { label: "option_0", identifier: "https://example.org/option_0"},
-                { label: "option_1", identifier: "https://example.org/option_1"}
+            category1: [
+                { label: "annotatedValue1", identifier: "https://example.org/option_1"},
+                { label: "annotatedValue2", identifier: "https://example.org/option_2"}
             ]
         },
         columnToCategoryMap: {
 
-            "column1": "category1"
+            column1: "category1"
         },
 
         dataDictionary: {
             annotated: {
-                valueMap: { "rawValue1": "annotatedValue1" }
+                column1: {
+                    valueMap: { "rawValue1": "annotatedValue1" }
+                }
             }
         }
     }
@@ -29,12 +31,69 @@ let store = {
 
 describe("getCategoricalJsonOutput", () => {
 
-    it("IsAbout test", () => {
+    it.skip("Make sure categorical json output is schema compliant", () => {
 
-        store = {};
+        let columnName = "column1";
+
+        // Act - Get formatted json output data for discrete value column
+        const output = store.getters.getCategoricalJsonOutput(store.state)(columnName);
+
+        // Assert - Current annotated data dictionary schema compliance
+
+        // Parent level
+
+        expect(output).to.have.property("Annotations");
+
+        // Child level
+
+        expect(output.Annotations).to.have.property("IsAbout");
+        expect(output.Annotations).to.have.property("Levels");
+
+        // Grandchild level
+        expect(output.Annotations.IsAbout).to.have.property("Label");
+        expect(output.Annotations.IsAbout).to.have.property("TermURL");
+        Object.keys(output.Annotations.Levels).forEach(rawValue => {
+
+            expect(output.Annotations.Levels[rawValue]).to.have.property("Label");
+            expect(output.Annotations.Levels[rawValue]).to.have.property("TermURL");
+        });
     });
 
-    it("Levels test", () => {
+    it("Make sure 'IsAbout' fields are properly formatted", () => {
 
+        let columnName = "column1";
+        let category = "category1";
+
+        // Act - Get formatted json output data for discrete value column
+        const output = store.getters.getCategoricalJsonOutput(store.state)(columnName);
+
+        // Assert - Label in this column's 'IsAbout' section to be its assigned category
+        expect(output.Annotations.IsAbout.Label).to.equal(category);
+
+        // Assert - TermURL in this column's 'IsAbout' section is properly formatted
+        // with prefix, colon, and capitalized term
+        expect(output.Annotations.IsAbout.TermURL).to.equal(
+            store.state.appSetting.termURLPrefix + ":"
+            + category[0].toUpperCase() + category.substring(1));
+    });
+
+    it("Make sure 'Levels' contains correctly transformed value map data from the store's annotated data dictionary", () => {
+
+        let columnName = "column1";
+
+        // Act - Get formatted json output data for discrete value column
+        const output = store.getters.getCategoricalJsonOutput(store.state)(columnName);
+
+        // Assert - Keys in 'Levels' are raw values from the value map
+        expect(Object.keys(output.Annotations.Levels)).to.deep.equal(
+            Object.keys(store.state.dataDictionary.annotated[columnName].valueMap));
+
+        // Assert - Labels in each object in 'Levels' should match annotated value from the
+        // store's annotated data dictionary value map
+        Object.keys(output.Annotations.Levels).forEach(rawValue => {
+
+            expect(output.Annotations.Levels[rawValue].Label).to.equal(
+                store.state.dataDictionary.annotated[columnName].valueMap[rawValue]);
+        });
     });
 });

--- a/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
+++ b/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
@@ -31,7 +31,8 @@ let store = {
 
                 column1: {
 
-                    valueMap: { "rawValue1": "https://example.org/option_1" }
+                    valueMap: { "rawValue1": "https://example.org/option_1" },
+                    missingValues: {0: "missing"}
                 }
             }
         }
@@ -55,6 +56,7 @@ describe("getCategoricalJsonOutput", () => {
 
         expect(output.Annotations).to.have.property("IsAbout");
         expect(output.Annotations).to.have.property("Levels");
+        expect(output.Annotations).to.have.property("MissingValues");
 
         // Grandchild level
         expect(output.Annotations.IsAbout).to.have.property("Label");
@@ -94,5 +96,11 @@ describe("getCategoricalJsonOutput", () => {
 
             expect(output.Annotations.Levels[rawValue].Label).to.equal("annotatedValue1");
         });
+    });
+
+    it("Make sure 'MissingValues' is the same as 'missingValues' from annotated data dictionary ", () => {
+        const output = store.getters.getCategoricalJsonOutput(store.state)(columnName);
+
+        expect(Object.keys(output.Annotations.MissingValues)).to.deep.equal(Object.keys({0: "missing"}));
     });
 });

--- a/store/index.js
+++ b/store/index.js
@@ -11,9 +11,7 @@ export const state = () => ({
     appSetting: {
 
         // The string label applied to values designated as "missing values" when the data are annotated.
-        missingValueLabel: "missing value",
-
-        termURLPrefix: "nb"
+        missingValueLabel: "missing value"
     },
 
     categoricalOptions: {
@@ -37,17 +35,20 @@ export const state = () => ({
         "Age": {
 
             componentName: "annot-continuous-values",
-            explanation: "This is an explanation for how to annotate age."
+            explanation: "This is an explanation for how to annotate age.",
+            identifier: "nb:hasAge"
         },
         "Sex": {
 
             componentName: "annot-categorical",
-            explanation: "This is an explanation for how to annotate sex."
+            explanation: "This is an explanation for how to annotate sex.",
+            identifier: "nb:hasSex"
         },
         "Diagnosis": {
 
             componentName: "annot-categorical",
-            explanation: "This is an explanation for how to annotate diagnosis."
+            explanation: "This is an explanation for how to annotate diagnosis.",
+            identifier: "nb:hasDiagnosis"
         }
     },
 
@@ -171,11 +172,8 @@ export const getters = {
         // A. Label matches the assigned category
         formattedOutput.Annotations.IsAbout.Label = category;
 
-        // B. Term includes a prefix followed by colon and then first-letter uppercased version of category
-        // NOTE: All categories are uppercased but this is not guaranteed with future custom categories
-        // specified by the user
-        formattedOutput.Annotations.IsAbout.TermURL = p_state.appSetting.termURLPrefix + ":" +
-            category[0].toUpperCase() + category.substring(1);
+        // B. Term matches the category identifier
+        formattedOutput.Annotations.IsAbout.TermURL = p_state.categories[category].identifier;
 
         // 2. Fill out Annotations 'Levels' section
         Object.keys(annotatedDictColumn.valueMap).forEach(rawValue => {

--- a/store/index.js
+++ b/store/index.js
@@ -182,8 +182,7 @@ export const getters = {
 
             p_state.categoricalOptions[category].forEach(option => {
 
-                if ( annotatedDictColumn.valueMap[rawValue] === option.label ) {
-
+                if ( annotatedDictColumn.valueMap[rawValue] === option.identifier ) {
                     formattedOutput.Annotations.Levels[rawValue].Label = option.label;
                     formattedOutput.Annotations.Levels[rawValue].TermURL = option.identifier;
                 }

--- a/store/index.js
+++ b/store/index.js
@@ -157,7 +157,11 @@ export const getters = {
 
             Annotations: {
 
-                IsAbout: {},
+                IsAbout: {
+
+                    Label: "",
+                    TermURL: ""
+                },
                 Levels: {}
             }
         };
@@ -175,6 +179,8 @@ export const getters = {
 
         // 2. Fill out Annotations 'Levels' section
         Object.keys(annotatedDictColumn.valueMap).forEach(rawValue => {
+
+            formattedOutput.Annotations.Levels[rawValue] = {};
 
             p_state.categoricalOptions[category].forEach(option => {
 

--- a/store/index.js
+++ b/store/index.js
@@ -148,6 +148,47 @@ export const getters = {
         return p_state.categories[p_category].componentName;
     },
 
+    getCategoricalJsonOutput: (p_state) => (p_columnName) => {
+
+        // 0. Initialize output object
+        const annotatedDictColumn = p_state.dataDictionary.annotated[p_columnName];
+        const category = p_state.columnToCategoryMap[p_columnName];
+        const formattedOutput = {
+
+            Annotations: {
+
+                IsAbout: {},
+                Levels: {}
+            }
+        };
+
+        // 1. Fill out Annotations 'IsAbout' section
+
+        // A. Label matches the assigned category
+        formattedOutput.Annotations.IsAbout.Label = category;
+
+        // B. Term includes a prefix followed by colon and then first-letter uppercased version of category
+        // NOTE: All categories are uppercased but this is not guaranteed with future custom categories
+        // specified by the user
+        formattedOutput.Annotations.IsAbout.TermURL = p_state.appSetting.termURLPrefix + ":" +
+            category[0].toUpperCase() + category.substring(1);
+
+        // 2. Fill out Annotations 'Levels' section
+        Object.keys(annotatedDictColumn.valueMap).forEach(rawValue => {
+
+            p_state.categoricalOptions[category].forEach(option => {
+
+                if ( annotatedDictColumn.valueMap[rawValue] === option.label ) {
+
+                    formattedOutput.Annotations.Levels[rawValue].Label = option.label;
+                    formattedOutput.Annotations.Levels[rawValue].TermURL = option.identifier;
+                }
+            });
+        });
+
+        return formattedOutput;
+    },
+
     getCategoricalOptions: (p_state) => (p_column) => {
 
         // Return the options for this column listed in the current (hardcoded)
@@ -236,52 +277,6 @@ export const getters = {
     getHeuristic: (p_state) => (p_columnName) => {
 
         return p_state.dataDictionary.annotated[p_columnName].transformationHeuristic;
-    },
-
-    getJsonOutputCategorical: (p_state) => (p_columnName) => {
-
-        // 0. Initialized output object
-        const annotatedDictColumn = p_state.dataDictionary.annotated[p_columnName];
-        const category = p_state.columnToCategoryMap[p_columnName];
-        const formattedOutput = {
-
-            Annotations: {
-
-                IsAbout: {},
-                Levels: {}
-            }
-        };
-
-        // 1. Fill out Annotations 'IsAbout' section
-        formattedOutput.Annotations.IsAbout.Label = category;
-        formattedOutput.Annotations.IsAbout.TermURL = p_state.appSetting.termURLPrefix +
-            category[0].toLowerCase() + category.substring(1);
-
-        // 2. Fill out Annotations 'Levels' section
-        Object.keys(annotatedDictColumn.valueMap).forEach(rawValue => {
-
-            p_state.categoricalOptions[category].forEach(option => {
-
-                if ( annotatedDictColumn.valueMap[rawValue] === option.label ) {
-
-                    formattedOutput.Annotations.Levels[rawValue].Label = option.label;
-                    formattedOutput.Annotations.Levels[rawValue].TermURL = option.identifier;
-                }
-            });
-        });
-
-        // 3. Copy over any other sections from the annotated data dictionary
-        Object.keys(annotatedDictColumn).forEach(dictKey => {
-
-            // A. Copy over all other values from the annotated data dictionary except the valuemap
-            if ( "valueMap" !== dictKey ) {
-
-                formattedOutput[dictKey] =
-                    Object.assign({}, annotatedDictColumn[dictKey]);
-            }
-        });
-
-        return formattedOutput;
     },
 
     getMappedCategories: (p_state) => (p_categorySkipList=[]) => {

--- a/store/index.js
+++ b/store/index.js
@@ -36,19 +36,19 @@ export const state = () => ({
 
             componentName: "annot-continuous-values",
             explanation: "This is an explanation for how to annotate age.",
-            identifier: "nb:hasAge"
+            identifier: "nb:Age"
         },
         "Sex": {
 
             componentName: "annot-categorical",
             explanation: "This is an explanation for how to annotate sex.",
-            identifier: "nb:hasSex"
+            identifier: "nb:Sex"
         },
         "Diagnosis": {
 
             componentName: "annot-categorical",
             explanation: "This is an explanation for how to annotate diagnosis.",
-            identifier: "nb:hasDiagnosis"
+            identifier: "nb:Diagnosis"
         }
     },
 
@@ -190,9 +190,7 @@ export const getters = {
             });
         });
 
-        Object.keys(annotatedDictColumn.missingValues).forEach(key => {
-            formattedOutput.Annotations.MissingValues.push(annotatedDictColumn.missingValues[key]);
-        });
+        formattedOutput.Annotations.MissingValues = annotatedDictColumn.missingValues;
 
         return formattedOutput;
     },

--- a/store/index.js
+++ b/store/index.js
@@ -164,7 +164,7 @@ export const getters = {
                     TermURL: ""
                 },
                 Levels: {},
-                MissingValues: {}
+                MissingValues: []
             }
         };
 
@@ -190,7 +190,9 @@ export const getters = {
             });
         });
 
-        formattedOutput.Annotations.MissingValues = annotatedDictColumn.missingValues;
+        Object.keys(annotatedDictColumn.missingValues).forEach(key => {
+            formattedOutput.Annotations.MissingValues.push(annotatedDictColumn.missingValues[key]);
+        });
 
         return formattedOutput;
     },

--- a/store/index.js
+++ b/store/index.js
@@ -163,7 +163,8 @@ export const getters = {
                     Label: "",
                     TermURL: ""
                 },
-                Levels: {}
+                Levels: {},
+                MissingValues: {}
             }
         };
 
@@ -188,6 +189,8 @@ export const getters = {
                 }
             });
         });
+
+        formattedOutput.Annotations.MissingValues = annotatedDictColumn.missingValues;
 
         return formattedOutput;
     },


### PR DESCRIPTION
Closes #406  
See also #408 

- [ ] New getter introduced in store `getCategoricalJsonOutput` that takes a column name and outputs a json object with annotated values for that column that is compliant with the schema as noted in #406 
- [ ] New unit test file `store-getter-getCategoricalJsonOutput.cy.js` with tests for schema compliance and value/value formatting checks for the `'IsAbout'` and `'Levels'` sections of the json output
