### PR TITLE
[ENH] Implemented getter to create JSON representation of continuous column

### DIFF
--- a/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
+++ b/cypress/unit/store-getter-getCategoricalJsonOutput.cy.js
@@ -63,37 +63,4 @@ describe("getCategoricalJsonOutput", () => {
                 }
         });
     });
-
-    it("Make sure 'IsAbout' fields are properly formatted", () => {
-
-        // Act - Get formatted json output data for discrete value column
-        const output = store.getters.getCategoricalJsonOutput(store.state)("column1");
-
-        // Assert - Label in this column's 'IsAbout' section to be its assigned category
-        expect(output.Annotations.IsAbout.Label).to.equal("category1");
-
-        // Assert - TermURL in this column's 'IsAbout' section is properly formatted
-        // with prefix, colon, and capitalized term
-        expect(output.Annotations.IsAbout.TermURL).to.equal("nb:hasCategory1");
-    });
-
-    it("Make sure 'Levels' contains correctly transformed value map data from the store's annotated data dictionary", () => {
-
-        // Act - Get formatted json output data for discrete value column
-        const output = store.getters.getCategoricalJsonOutput(store.state)("column1");
-
-        // Assert - Keys in 'Levels' are raw values from the value map
-        expect(Object.keys(output.Annotations.Levels)).to.deep.equal(
-            Object.keys(store.state.dataDictionary.annotated["column1"].valueMap));
-
-        // Assert - Labels in each object in 'Levels' should match label from the
-        // store's annotated data dictionary value map
-        expect(output.Annotations.Levels["rawValue1"].Label).to.equal("annotatedValue1");
-    });
-
-    it("Make sure 'MissingValues' is the same as 'missingValues' from annotated data dictionary ", () => {
-        const output = store.getters.getCategoricalJsonOutput(store.state)("column1");
-
-        expect(output.Annotations.MissingValues).to.deep.equal(["missing"]);
-    });
 });

--- a/cypress/unit/store-getter-getContinousJsonOutput.cy.js
+++ b/cypress/unit/store-getter-getContinousJsonOutput.cy.js
@@ -26,11 +26,6 @@ let store = {
             }
         },
         transformationHeuristics: {
-            float: {
-                TermURL: "nb:float",
-                Label: "float value"
-            },
-
             bounded: {
                 TermURL: "nb:bounded",
                 Label: "bounded value"
@@ -39,6 +34,11 @@ let store = {
             euro: {
                 TermURL: "nb:euro",
                 Label: "european decimal value"
+            },
+
+            float: {
+                TermURL: "nb:float",
+                Label: "float value"
             },
 
             int: {
@@ -58,7 +58,7 @@ describe("getcontinuousJsonOutput", () => {
 
     it("Make sure continuous json output is schema compliant", () => {
 
-        // Act - Get formatted json output data for discrete value column
+        // Act - Get formatted json output data for continuous value column
         const output = store.getters.getContinuousJsonOutput(store.state)("column1");
 
         // Assert - Current annotated data dictionary schema compliance

--- a/cypress/unit/store-getter-getContinousJsonOutput.cy.js
+++ b/cypress/unit/store-getter-getContinousJsonOutput.cy.js
@@ -1,0 +1,81 @@
+import { getters } from "~/store";
+
+let store = {
+
+    getters: getters,
+
+    state: {
+
+        categories: {
+            "category1": {
+
+                componentName: "annot-continuous-values",
+                explanation: "This is an explanation for how to annotate category1.",
+                identifier: "nb:hasCategory1"
+            }
+        },
+        columnToCategoryMap: { column1: "category1" },
+        dataDictionary: {
+
+            annotated: {
+
+                column1: {
+
+                    transformationHeuristic: "euro"
+                }
+            }
+        },
+        transformationHeuristics: {
+            float: {
+                TermURL: "nb:float",
+                Label: "float value"
+            },
+
+            bounded: {
+                TermURL: "nb:bounded",
+                Label: "bounded value"
+            },
+
+            euro: {
+                TermURL: "nb:euro",
+                Label: "european decimal value"
+            },
+
+            int: {
+                TermURL: "nb:int",
+                Label: "integer value"
+            },
+
+            iso8601: {
+                TermURL: "nb",
+                Label: "period of time defined according to the ISO8601 standard"
+            }
+        }
+    }
+};
+
+describe("getcontinuousJsonOutput", () => {
+
+    it("Make sure continuous json output is schema compliant", () => {
+
+        // Act - Get formatted json output data for discrete value column
+        const output = store.getters.getContinuousJsonOutput(store.state)("column1");
+
+        // Assert - Current annotated data dictionary schema compliance
+        expect(output).to.deep.equal(
+            {
+
+                Annotations: {
+                    IsAbout: {
+                        Label: "category1",
+                        TermURL: "nb:hasCategory1"
+                    },
+                    Transformation: {
+
+                        Label: "european decimal value",
+                        TermURL: "nb:euro"
+                    }
+                }
+        });
+    });
+});

--- a/cypress/unit/store-getter-getTransformOptions.cy.js
+++ b/cypress/unit/store-getter-getTransformOptions.cy.js
@@ -15,11 +15,6 @@ let store = {
         },
 
         transformationHeuristics: {
-            float: {
-                TermURL: "nb:float",
-                Label: "float value"
-            },
-
             bounded: {
                 TermURL: "nb:bounded",
                 Label: "bounded value"
@@ -28,6 +23,11 @@ let store = {
             euro: {
                 TermURL: "nb:euro",
                 Label: "european decimal value"
+            },
+
+            float: {
+                TermURL: "nb:float",
+                Label: "float value"
             },
 
             int: {

--- a/cypress/unit/store-getter-getTransformOptions.cy.js
+++ b/cypress/unit/store-getter-getTransformOptions.cy.js
@@ -52,7 +52,7 @@ describe("getTransformOptions", () => {
 
         // Assert
         expect(options).to.deep.equal([
-            "float", "bounded", "euro", "int", "iso8601"
+            "bounded", "euro", "float", "int", "iso8601"
         ]);
     });
 });

--- a/cypress/unit/store-getter-getTransformOptions.cy.js
+++ b/cypress/unit/store-getter-getTransformOptions.cy.js
@@ -15,11 +15,30 @@ let store = {
         },
 
         transformationHeuristics: {
+            float: {
+                TermURL: "nb:float",
+                Label: "float value"
+            },
 
-            "annot-continuous-values": [
+            bounded: {
+                TermURL: "nb:bounded",
+                Label: "bounded value"
+            },
 
-                "float", "bounded", "euro", "int", "isoyear"
-            ]
+            euro: {
+                TermURL: "nb:euro",
+                Label: "european decimal value"
+            },
+
+            int: {
+                TermURL: "nb:int",
+                Label: "integer value"
+            },
+
+            iso8601: {
+                TermURL: "nb",
+                Label: "period of time defined according to the ISO8601 standard"
+            }
         }
     }
 };
@@ -33,7 +52,7 @@ describe("getTransformOptions", () => {
 
         // Assert
         expect(options).to.deep.equal([
-            "float", "bounded", "euro", "int", "isoyear"
+            "float", "bounded", "euro", "int", "iso8601"
         ]);
     });
 });

--- a/store/index.js
+++ b/store/index.js
@@ -423,11 +423,7 @@ export const getters = {
 
     getTransformOptions: (p_state) => (p_category) => {
 
-        // 0. Get the data type of the given category
-        const columnDataType = p_state.categories[p_category].componentName;
-
-        // Return the set of transformation heuristics for this data type
-        return p_state.transformationHeuristics[columnDataType];
+        return Object.keys(p_state.transformationHeuristics);
     },
 
     getUniqueValues: (p_state) => (p_category, p_maxValues="None") => {

--- a/store/index.js
+++ b/store/index.js
@@ -149,11 +149,6 @@ export const state = () => ({
     // TODO: Assess whether this is the best place and configuration for storing
     // transformation heuristics
     transformationHeuristics: {
-        float: {
-            TermURL: "nb:float",
-            Label: "float value"
-        },
-
         bounded: {
             TermURL: "nb:bounded",
             Label: "bounded value"
@@ -162,6 +157,11 @@ export const state = () => ({
         euro: {
             TermURL: "nb:euro",
             Label: "european decimal value"
+        },
+
+        float: {
+            TermURL: "nb:float",
+            Label: "float value"
         },
 
         int: {

--- a/store/index.js
+++ b/store/index.js
@@ -257,6 +257,33 @@ export const getters = {
         return ( 0 === p_state.dataTable.length) ? [] : Object.keys(p_state.dataTable[0] );
     },
 
+    getContinuousJsonOutput: (p_state) => (p_columnName) => {
+        const annotatedDictColumn = p_state.dataDictionary.annotated[p_columnName];
+        const category = p_state.columnToCategoryMap[p_columnName];
+        const formattedOutput = {
+
+            Annotations: {
+
+                IsAbout: {
+                    Label: "",
+                    TermURL: ""
+                },
+                Transformation: {
+                    Label: "",
+                    TermURL: ""
+                }
+            }
+        };
+
+        formattedOutput.Annotations.IsAbout.Label = category;
+
+        formattedOutput.Annotations.IsAbout.TermURL = p_state.categories[category].identifier;
+
+        formattedOutput.Annotations.Transformation = p_state.transformationHeuristics[annotatedDictColumn.transformationHeuristic];
+
+        return formattedOutput;
+    },
+
     getExplanation: (p_state) => (p_category) => {
 
         return ( "explanation" in p_state.categories[p_category] ) ?

--- a/store/index.js
+++ b/store/index.js
@@ -149,13 +149,30 @@ export const state = () => ({
     // TODO: Assess whether this is the best place and configuration for storing
     // transformation heuristics
     transformationHeuristics: {
+        float: {
+            TermURL: "nb:float",
+            Label: "float value"
+        },
 
-        // "annot-continuous-values": [
-        //     "", "float", "bounded", "euro", "int", "isoyear"
-        // ]
-        "annot-continuous-values": [
-            "", "float", "bounded", "euro", "int"
-        ]
+        bounded: {
+            TermURL: "nb:bounded",
+            Label: "bounded value"
+        },
+
+        euro: {
+            TermURL: "nb:euro",
+            Label: "european decimal value"
+        },
+
+        int: {
+            TermURL: "nb:int",
+            Label: "integer value"
+        },
+
+        iso8601: {
+            TermURL: "nb",
+            Label: "period of time defined according to the ISO8601 standard"
+        }
     }
 });
 


### PR DESCRIPTION
Closes #407 

Changes proposed in this pull request:

- Modified `transformationHeuristics` according to this [comment](https://github.com/neurobagel/annotation_tool/issues/407#issuecomment-1553385867)
- Updated `getTransformOptions` getter
- Updated `getTransformOptions` getter's unit test
- Implemented `getContinuousJsonOutput` getter
- Implemented unit test for `getContinuousJsonOutput` getter
- Removed unnecessary test cases from `getCategoricalJsonOutput` getter's unit test

## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [ ] PR links to Github issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Code is properly formatted


For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions