### PR TITLE
[MAINT] Instructed dependabot to ignore nuxt and vue major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,13 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      - dependency-name: 'nuxt'
+        update-types: ["version-update:semver-major"]
+      - dependency-name: 'vue'
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Closes #454 
See also #453

Changes proposed in this pull request:

- Updated dependabot.yml to ignore nuxt and vue major version updates

## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [x] PR links to Github issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Code is properly formatted


For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
