### PR TITLE
[MAINT] Instructed dependabot to ignore webpack major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: 'vue'
         update-types: ["version-update:semver-major"]
+      - dependency-name: 'webpack'
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Closes #464
See also #457 

Changes proposed in this pull request:

- Update dependabot.yml to ignore webpack major version updates

## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [x] PR links to Github issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Code is properly formatted


For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
