### PR TITLE
[MAINT] Updating to bootrap-vue 2.23.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@nuxtjs/axios": "^5.13.6",
         "bootstrap": "^4.6.1",
-        "bootstrap-vue": "^2.21.2",
+        "bootstrap-vue": "^2.23.1",
         "core-js": "^3.19.3",
         "file-saver": "^2.0.5",
         "fs": "^0.0.1-security",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@nuxtjs/axios": "^5.13.6",
     "bootstrap": "^4.6.1",
-    "bootstrap-vue": "^2.21.2",
+    "bootstrap-vue": "^2.23.1",
     "core-js": "^3.19.3",
     "file-saver": "^2.0.5",
     "fs": "^0.0.1-security",


### PR DESCRIPTION
Closers #471 and addresses #463.

Re-bumping up `bootstrap-vue` to v2.23.1. This is was a followup to see why the categorization page was breaking in the deployed, static build of the app.

As it turns out, `bootstrap-vue` does not (fully) support `bootstrap` v5. (See [https://bootstrap-vue.org/docs](https://bootstrap-vue.org/docs).

## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [ ] PR links to Github issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Code is properly formatted
