### PR TITLE
Linter fixes for new eslint-plugin-cypress version

### DIFF
--- a/cypress/component/annot-continuous-values.cy.js
+++ b/cypress/component/annot-continuous-values.cy.js
@@ -137,7 +137,8 @@ describe("Continuous values component", () => {
         });
 
         // Act
-        cy.get("[data-cy='selectTransform_column1']").click().contains("euro").click();
+        cy.get("[data-cy='selectTransform_column1']").click();
+        cy.get("[data-cy='selectTransform_column1']").contains("euro").click();
 
         // Assert - With euro transformation selected, preview values should have ',' replaced with '.'
         cy.get("[data-cy='dataTable-column1'] tr").eq(1)
@@ -216,7 +217,8 @@ describe("Continuous values component", () => {
         });
 
         // Act
-        cy.get("[data-cy='selectTransform_column1']").click().contains("euro").click();
+        cy.get("[data-cy='selectTransform_column1']").click();
+        cy.get("[data-cy='selectTransform_column1']").contains("euro").click();
 
         // Assert - With euro transformation selected, preview values should have ',' replaced with '.'
         cy.get("[data-cy='dataTable-column1'] tr").eq(1)
@@ -228,7 +230,8 @@ describe("Continuous values component", () => {
 
         // Act
         cy.get(".nav-link").contains("column2").click();
-        cy.get("[data-cy='selectTransform_column2']").click().contains("euro").click();
+        cy.get("[data-cy='selectTransform_column2']").click();
+        cy.get("[data-cy='selectTransform_column2']").contains("euro").click();
 
         // Assert - With euro transformation selected, preview values should have ',' replaced with '.'
         cy.get("[data-cy='dataTable-column2'] tr").eq(1)

--- a/cypress/component/index_page.cy.js
+++ b/cypress/component/index_page.cy.js
@@ -96,7 +96,7 @@ describe("The index page", () => {
         });
 
         // Act
-        cy.get("[data-cy='data-table-selector']").contains("Choose file").click().selectFile("@exampleTable");
+        cy.get("[data-cy='data-table-selector']").contains("Choose file").selectFile("@exampleTable");
 
         // Assert
         cy.get("@dispatchSpy").should("have.been.calledWith", "processDataTable", {
@@ -128,7 +128,7 @@ describe("The index page", () => {
         });
 
         // Act
-        cy.get("[data-cy='data-dictionary-selector']").contains("Choose file").click().selectFile("@exampleDictionary");
+        cy.get("[data-cy='data-dictionary-selector']").contains("Choose file").selectFile("@exampleDictionary");
 
         // Assert
         cy.get("@dispatchSpy").should("have.been.calledWith", "processDataDictionary", {

--- a/cypress/e2e/app/simple-e2etest.cy.js
+++ b/cypress/e2e/app/simple-e2etest.cy.js
@@ -45,7 +45,6 @@ describe("End to end test using a simple UI path through the app", () => {
             // B. Select data table file
             cy.get("[data-cy='data-table-selector']")
                 .contains("Choose file")
-                .click()
                 .selectFile(dataFolder + p_dataset.data_table);
 
             // C. Assert that categorization nav item and next button are enabled
@@ -54,7 +53,6 @@ describe("End to end test using a simple UI path through the app", () => {
             // D. Select participants dictionary
             cy.get("[data-cy='data-dictionary-selector']")
                 .contains("Choose file")
-                .click()
                 .selectFile(dataFolder + p_dataset.data_dictionary);
 
             // E. Click the next page button to proceed to the categorization page
@@ -103,7 +101,8 @@ describe("End to end test using a simple UI path through the app", () => {
 
                     // B. Select the 'float' transformation heuristic
                     // :data-cy="'selectTransform_' + columnName" where columnName is age
-                    cy.get("[data-cy='selectTransform_age']").click().type("float{enter}");
+                    cy.get("[data-cy='selectTransform_age']").click();
+                    cy.get("[data-cy='selectTransform_age']").type("float{enter}");
 
                     // D. Assert that next page nav and button are enabled for download page
                     cy.assertNextPageAccess("download", true);

--- a/cypress/e2e/page/annotation-pagetests.cy.js
+++ b/cypress/e2e/page/annotation-pagetests.cy.js
@@ -84,7 +84,8 @@ describe("tests on annotation page ui with programmatic state loading and store 
 
                     // B. Select the 'float' transformation heuristic
                     // :data-cy="'selectTransform_' + columnName"
-                    cy.get("[data-cy='selectTransform_age']").click().type("float{enter}");
+                    cy.get("[data-cy='selectTransform_age']").click();
+                    cy.get("[data-cy='selectTransform_age']").type("float{enter}");
 
                     // 5. Assert annotation nav and next page button are enabled
                     cy.assertNextPageAccess("download", true);
@@ -124,8 +125,10 @@ describe("tests on annotation page ui with programmatic state loading and store 
                         .click();
 
                     // B. Select annotation choices for 'Sex' column values
-                    cy.get("[data-cy='categoricalSelector_0']").click().type("male{enter}");
-                    cy.get("[data-cy='categoricalSelector_1']").click().type("female{enter}");
+                    cy.get("[data-cy='categoricalSelector_0']").click();
+                    cy.get("[data-cy='categoricalSelector_0']").type("male{enter}");
+                    cy.get("[data-cy='categoricalSelector_1']").click();
+                    cy.get("[data-cy='categoricalSelector_1']").type("female{enter}");
 
                     // 5. Assert annotation nav and next page button are enabled
                     cy.assertNextPageAccess("download", true);
@@ -166,9 +169,12 @@ describe("tests on annotation page ui with programmatic state loading and store 
 
                     // B. Enter annotated values for each unique value in the 'Diagnosis'-categorized column
                     // NOTE: This value of '3' should be pulled from the interface via the number of unique diagnosis values returned
-                    cy.get("[data-cy='categoricalSelector_0']").click().type("Depressive{enter}");
-                    cy.get("[data-cy='categoricalSelector_1']").click().type("Parkins{enter}");
-                    cy.get("[data-cy='categoricalSelector_2']").click().type("Smoker{enter}");
+                    cy.get("[data-cy='categoricalSelector_0']").click();
+                    cy.get("[data-cy='categoricalSelector_0']").type("Depressive{enter}");
+                    cy.get("[data-cy='categoricalSelector_1']").click();
+                    cy.get("[data-cy='categoricalSelector_1']").type("Parkins{enter}");
+                    cy.get("[data-cy='categoricalSelector_2']").click();
+                    cy.get("[data-cy='categoricalSelector_2']").type("Smoker{enter}");
 
                     // 5. Assert annotation nav and next page button are enabled
                     cy.assertNextPageAccess("download", true);

--- a/cypress/e2e/page/index-pagetests.cy.js
+++ b/cypress/e2e/page/index-pagetests.cy.js
@@ -44,7 +44,6 @@ describe("Tests on the index page via store interaction", () => {
                 // 2. Select data table file
                 cy.get("[data-cy='data-table-selector']")
                     .contains("Choose file")
-                    .click()
                     .selectFile(fixturesFolder + p_dataset.source_folder + p_dataset.data_table);
 
                 // 3. Assert that categorization nav item and next button are enabled
@@ -86,7 +85,6 @@ describe("Tests on the index page via store interaction", () => {
                 // 2. Select data table file
                 cy.get("[data-cy='data-table-selector']")
                     .contains("Choose file")
-                    .click()
                     .selectFile(dataFolder + p_dataset.data_table);
 
                 // 3. Assert that categorization nav item and next button are enabled
@@ -95,7 +93,6 @@ describe("Tests on the index page via store interaction", () => {
                 // 4. Select participants dictionary
                 cy.get("[data-cy='data-dictionary-selector']")
                     .contains("Choose file")
-                    .click()
                     .selectFile(dataFolder + p_dataset.data_dictionary);
 
                 // 3. Assert that categorization nav item and next button are *still* enabled


### PR DESCRIPTION
Fixes #468. Since that PR is just merging into master, the order would be to review/merge these changes and then to merge the `eslint-plugin-cypress` afterwards.

Linter fixes include unchaining subsequent actions after clicking on an item in the interface (via an additional statement using `cy.get` on the same html object), and a fix to remove extraneous chaining click call for selecting the data table and data dictionary files.

## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [ ] PR links to Github issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Code is properly formatted
