### PR TITLE
[ENH] Updated branding and shortcuts for navbar

### DIFF
--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -6,8 +6,13 @@
         <b-navbar toggleable="lg" type="light" variant="light">
 
             <!-- Brand -->
-            <b-navbar-brand class="brand-styling">
-                <h1>{{ uiText.toolName }}: {{ uiText.subtitle }}</h1>
+            <b-navbar-brand class="brand-styling" href="https://www.neurobagel.org/" target="_blank">
+                <b-row style="padding: 0; margin: 0;">
+                    {{ uiText.toolName }}
+                </b-row>
+                <b-row id="nav-subtitle" style="padding: 0; margin: 0;">
+                    {{ uiText.subtitle }}
+                </b-row>
             </b-navbar-brand>
 
             <!-- Collapse toggle -->
@@ -29,6 +34,32 @@
                         :to="navItem.location"
                         @click="setCurrentPage(navItem.pageName)">
                         {{ navItem.fullName }}
+                    </b-nav-item>
+                    <span id="nav-separator">|</span>
+                    <b-nav-item
+                        class="dark"
+                        data-cy="version"
+                        href="https://github.com/neurobagel/annotation_tool/tree/v0.2.0/">
+                        {{ uiText.version }}
+                        <!-- style="border-left: 2px solid #212529;" -->
+                    </b-nav-item>
+                    <b-nav-item
+                        class="dark"
+                        data-cy="docs"
+                        href="https://www.neurobagel.org/documentation/" >
+                        {{ uiText.documentation }}
+                    </b-nav-item>
+                    <b-nav-item
+                        class="dark"
+                        data-cy="feedback"
+                        href="https://github.com/neurobagel/annotation_tool/issues/">
+                        {{ uiText.feedback }}
+                    </b-nav-item>
+                    <b-nav-item
+                        class="dark"
+                        data-cy="github"
+                        href="https://github.com/neurobagel/annotation_tool/">
+                        <b-icon icon="github" font-scale="1"/>
                     </b-nav-item>
 
                 </b-navbar-nav>
@@ -61,8 +92,11 @@
                 // Text for UI elements
                 uiText: {
 
+                    documentation: "Documentation",
+                    feedback: "Feedback",
                     subtitle: "Harmonize phenotypic data",
-                    toolName: "Annotation Tool"
+                    toolName: "Neurobagel Annotate",
+                    version: "v0.2.0"
                 }
             };
         },
@@ -118,7 +152,6 @@
 
     .brand-styling {
 
-        font-size: 2.25em;
         font-family: -apple-system,
             BlinkMacSystemFont,
             "Segoe UI",
@@ -132,12 +165,16 @@
             "Segoe UI Emoji",
             "Segoe UI Symbol",
             "Noto Color Emoji";
+        font-size: 2em;
+        font-weight: 700;
         padding-left: 1em;
     }
 
     .navbar {
 
         background-color: white !important;
+        padding-top: 1em;
+        padding-bottom: 1em;
     }
 
     .nav-item.dark a {
@@ -153,6 +190,19 @@
     .nav-item.success a {
 
         color: #28a745 !important;
+    }
+
+    #nav-separator {
+
+        font-size: 1.5em;
+    }
+
+    #nav-subtitle {
+
+        color: #470a68;
+        font-size: 16px;
+        font-weight: normal;
+        text-decoration: none;
     }
 
     #right-nav {

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -39,26 +39,30 @@
                     <b-nav-item
                         class="dark"
                         data-cy="version"
-                        href="https://github.com/neurobagel/annotation_tool/tree/v0.2.0/">
+                        href="https://github.com/neurobagel/annotation_tool/releases/tag/0.2.0"
+                        target="_blank">
                         {{ uiText.version }}
                         <!-- style="border-left: 2px solid #212529;" -->
                     </b-nav-item>
                     <b-nav-item
                         class="dark"
                         data-cy="docs"
-                        href="https://www.neurobagel.org/documentation/" >
+                        href="https://www.neurobagel.org/documentation/"
+                        target="_blank">
                         {{ uiText.documentation }}
                     </b-nav-item>
                     <b-nav-item
                         class="dark"
                         data-cy="feedback"
-                        href="https://github.com/neurobagel/annotation_tool/issues/">
+                        href="https://github.com/neurobagel/annotation_tool/issues/"
+                        target="_blank">
                         {{ uiText.feedback }}
                     </b-nav-item>
                     <b-nav-item
                         class="dark"
                         data-cy="github"
-                        href="https://github.com/neurobagel/annotation_tool/">
+                        href="https://github.com/neurobagel/annotation_tool/"
+                        target="_blank">
                         <b-icon icon="github" font-scale="1"/>
                     </b-nav-item>
 

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -7,7 +7,7 @@
 
             <!-- Brand -->
             <b-navbar-brand class="brand-styling">
-                <h1>{{ uiText.toolName }}</h1>
+                <h1>{{ uiText.toolName }}: uiText.subtitle</h1>
             </b-navbar-brand>
 
             <!-- Collapse toggle -->
@@ -61,6 +61,7 @@
                 // Text for UI elements
                 uiText: {
 
+                    subtitle: "Harmonize phenotypic data",
                     toolName: "Annotation Tool"
                 }
             };

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -7,7 +7,7 @@
 
             <!-- Brand -->
             <b-navbar-brand class="brand-styling">
-                <h1>{{ uiText.toolName }}: uiText.subtitle</h1>
+                <h1>{{ uiText.toolName }}: {{ uiText.subtitle }}</h1>
             </b-navbar-brand>
 
             <!-- Collapse toggle -->

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,7 +4,7 @@
 
         <!-- Data table file loading area -->
         <b-row>
-            <h2>{{ uiText.dataTableHeader }}</h2>
+            <h3>{{ uiText.dataTableHeader }}</h3>
         </b-row>
 
         <!-- Shows file contents -->
@@ -28,7 +28,7 @@
 
         <!-- Data dictionary file loading area -->
         <b-row>
-            <h2>{{ uiText.dataDictionaryHeader }}</h2>
+            <h3>{{ uiText.dataDictionaryHeader }}</h3>
         </b-row>
 
         <!-- Shows file contents -->


### PR DESCRIPTION
Closes #444 and #445 
See also [https://github.com/neurobagel/query-tool/issues/103](https://github.com/neurobagel/query-tool/issues/103) and [https://github.com/neurobagel/query-tool/issues/117](https://github.com/neurobagel/query-tool/issues/117)

To align with the new, cross-Neurobagel navbar shortcuts and styling, the following changes have been made to the annotation tool:

1. New and resized title: "Neurobagel Annotate"
2. New subtitle underneath title ("Harmonize phenotypic data")
3. Both title and subtitle link to [neurobagel.org](neurobagel.org)
4. New set of navbar shortcuts to the right of the annotation workflow (Home - Download) have been added separated by a vertical pipe character
5. The new navbar shortcuts include `v0.2.0` linking to the [release notes of the current version](https://github.com/neurobagel/annotation_tool/releases/tag/0.2.0), `Documentation` linking to the [Neurobagel documentation](https://www.neurobagel.org/documentation/), `Feedback` linking to the [annotation tool issues page](https://github.com/neurobagel/annotation_tool/issues/) and a `GitHub icon` linking to the [annotation tool repository](https://github.com/neurobagel/annotation_tool/)
6. All links open a new tab
7. The headings for the upload sections `Data Table` and `Data Dictionary` on the home page have been reduced to `h3` in order to be smaller than the new title size.

## Checklist

- [X] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [X] PR links to Github issue with mention `Closes #XXXX`
- [X] Tests pass
- [X] Code is properly formatted