### PR TITLE
[ENH] Added `Subject ID/Participant ID` to JSON output file

### DIFF
--- a/cypress/e2e/page/download-pagetests.cy.js
+++ b/cypress/e2e/page/download-pagetests.cy.js
@@ -78,6 +78,11 @@ describe("tests on download page ui via programmatic state loading and store int
 
                             expect(folderStateAfter[folderStateAfter.length - 1]).to.contain(dataDictionaryFilenameNoExt);
                         });
+                        // C. Check if the last file retrieved contains the Identifies property and its value under the participant_id key
+                        cy.readFile('cypress/downloads/' + folderStateAfter[folderStateAfter.length - 1]).then((fileContent) => {
+                            expect(fileContent.participant_id.Annotations).to.have.property("Identifies");
+                            expect(fileContent.participant_id.Annotations.Identifies).to.eq("participant");
+                          });
                     });
                 });
             });

--- a/store/index.js
+++ b/store/index.js
@@ -439,6 +439,19 @@ export const getters = {
 
                         columnOutput = p_getters.getContinuousJsonOutput(columnName);
                         break;
+
+                    default:
+                        columnOutput = {
+                            "Description": "A participant ID",
+                            Annotations: {
+
+                                IsAbout: {
+                                    Label: "Subject Unique Identifier",
+                                    TermURL: "nb:ParticipantID"
+                                },
+                                Identifies: "participant"
+                            }
+                        };
                 }
 
             }
@@ -722,6 +735,12 @@ export const mutations = {
         // NOTE: The latter are initialized here to eliminate checks for their
         // nullness in other store functions
         switch ( p_state.columnToCategoryMap[columnName] ) {
+            case "Subject ID":
+                p_state.dataDictionary.annotated[columnName] = Object.assign(
+                    {},
+                    p_state.dataDictionary.userProvided[columnName]
+                );
+                break;
 
             case "Age":
 


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include the [WIP] tag in its title, or create a draft PR. -->


<!---
Below is a suggested pull request template.
It's designed to capture info we've found to be useful in reviewing pull requests, but feel free to add more details you feel are relevant/necessary.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #477

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Updated `alterColumnCategoryMapping` mutation to add the column mapped to `Subject ID` to the annotated data dictionary in the state
- Update `getJSONOutput` getter to add `participant_id` to the output file
- Expanded `download-pagetests` to check for `identifies` property and its value under `participant_id` key of the output file

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions.
