### PR TITLE
[MNT] Removed `FromInt` age transformation

### DIFF
--- a/cypress/fixtures/examples/good/ds003653_participant_annotated_1698934398962.json
+++ b/cypress/fixtures/examples/good/ds003653_participant_annotated_1698934398962.json
@@ -16,7 +16,7 @@
                 "TermURL": "nb:Age"
             },
             "Transformation": {
-                "Label": "integer value",
+                "Label": "float value",
                 "TermURL": "nb:FromFloat"
             },
             "MissingValues": []

--- a/cypress/fixtures/examples/good/ds003653_participant_annotated_1698934398962.json
+++ b/cypress/fixtures/examples/good/ds003653_participant_annotated_1698934398962.json
@@ -17,7 +17,7 @@
             },
             "Transformation": {
                 "Label": "integer value",
-                "TermURL": "nb:FromInt"
+                "TermURL": "nb:FromFloat"
             },
             "MissingValues": []
         },

--- a/cypress/unit/store-getter-getContinousJsonOutput.cy.js
+++ b/cypress/unit/store-getter-getContinousJsonOutput.cy.js
@@ -44,11 +44,6 @@ let store = {
                 Label: "float value",
                 TermURL: "nb:FromFloat"
             },
-            int: {
-
-                Label: "integer value",
-                TermURL: "nb:FromInt"
-            },
             iso8601: {
 
                 Label: "period of time defined according to the ISO8601 standard",

--- a/cypress/unit/store-getter-getTransformOptions.cy.js
+++ b/cypress/unit/store-getter-getTransformOptions.cy.js
@@ -30,11 +30,6 @@ let store = {
                 Label: "float value"
             },
 
-            int: {
-                TermURL: "nb:FromInt",
-                Label: "integer value"
-            },
-
             iso8601: {
                 TermURL: "nb:FromISO8601",
                 Label: "period of time defined according to the ISO8601 standard"

--- a/cypress/unit/store-getter-getTransformOptions.cy.js
+++ b/cypress/unit/store-getter-getTransformOptions.cy.js
@@ -47,7 +47,7 @@ describe("getTransformOptions", () => {
 
         // Assert
         expect(options).to.deep.equal([
-            "bounded", "euro", "float", "int", "iso8601"
+            "bounded", "euro", "float", "iso8601"
         ]);
     });
 });

--- a/store/index.js
+++ b/store/index.js
@@ -137,12 +137,6 @@ export const state = () => ({
             TermURL: "nb:FromFloat"
         },
 
-        int: {
-
-            Label: "integer value",
-            TermURL: "nb:FromInt"
-        },
-
         iso8601: {
 
             Label: "period of time defined according to the ISO8601 standard",


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #636 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Enhancements:
- Remove the 'FromInt' age transformation from the store configuration and related test files.